### PR TITLE
Define generic API interfaces in Java and document the API in JavaDoc

### DIFF
--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/api/GenDeviceApi4Modbus.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/api/GenDeviceApi4Modbus.java
@@ -1,0 +1,151 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package communicator.api;
+
+import com.smartgridready.ns.v0.SGrBasicGenDataPointTypeType;
+import communicator.common.runtime.GenDriverException;
+import communicator.common.runtime.GenDriverModbusException;
+import communicator.common.runtime.GenDriverSocketException;
+
+/**
+ * The API defines read and write operations for SmartGridReady devices.
+ * The values can be provided as {@link String} or {@link SGrBasicGenDataPointTypeType}
+ * The implementing device will convert the data to their modbus format.
+ *
+ */
+public interface GenDeviceApi4Modbus {
+
+    /**
+     * Read a numeric or string value read a from a modbus device register.
+     * Numeric values read from the device are converted to their String representations.
+     * 
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint.
+     * @return The value converted to {@link java.lang.String}
+     * @throws GenDriverException If a general exception occurred.
+     * @throws GenDriverSocketException In case of communication errors with the modbus device.
+     * @throws GenDriverModbusException If the modbus command could not be interpreted/executed on the device.
+     */
+    String getVal(String profileName, String dataPointName)
+            throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+
+    /**
+     * Write a numeric or string value to a modbus register.
+     * Numeric values are converted from their String representation to the numeric format as defined in the
+     * external interface XML for the given datapoint.
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint.
+     * @param value The value in string representation.
+     * @throws GenDriverException If a general exception occurred.
+     * @throws GenDriverSocketException In case of communication errors with the modbus device.
+     * @throws GenDriverModbusException If the modbus command could not be interpreted/executed on the device.
+     */
+    String  setVal(String profileName, String dataPointName, String value)
+            throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+
+    /**
+     * Read a value from the modbus device in its generic datapoint representation (see {@link SGrBasicGenDataPointTypeType}).
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint.
+     * @return The value converted to {@link java.lang.String}
+     * @throws GenDriverException If a general exception occurred.
+     * @throws GenDriverSocketException In case of communication errors with the modbus device.
+     * @throws GenDriverModbusException If the modbus command could not be interpreted/executed on the device.
+     *
+     * @see SGrBasicGenDataPointTypeType
+     */
+    SGrBasicGenDataPointTypeType getValByGDPType(String profileName, String dataPointName)
+            throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+
+    /**
+     * Write a value to the modbus device using the generic datapoint representation (see {@link SGrBasicGenDataPointTypeType}).
+     * The value is converted from the format given within the {@code value} parameter to the value required
+     * by the modbus device (as defined within the external interface XML of the device).
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint.
+     * @param value The value as {@link SGrBasicGenDataPointTypeType}
+     * @throws GenDriverException If a general exception occurred.
+     * @throws GenDriverSocketException In case of communication errors with the modbus device.
+     * @throws GenDriverModbusException If the modbus command could not be interpreted/executed on the device.
+     *
+     * @see SGrBasicGenDataPointTypeType
+     */
+    void setValByGDPType(String profileName, String dataPointName, SGrBasicGenDataPointTypeType value)
+            throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+
+    /**
+     * Read an array of numeric or string values from the modbus device. The values are converted to their string
+     * representation.
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint.
+     * @return The values read from the device in their string representation.
+     * @throws GenDriverException If a general exception occurred.
+     * @throws GenDriverSocketException In case of communication errors with the modbus device.
+     * @throws GenDriverModbusException If the modbus command could not be interpreted/executed on the device.
+     */
+    String[] getValArr(String profileName, String dataPointName)
+            throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+
+    /**
+     * Read an array of numeric or string values from the modbus device. The values are converted to their
+     * generic datapoint representation as defined within the external interface XML (see {@link SGrBasicGenDataPointTypeType}).
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint.
+     * @return The values in their {@link SGrBasicGenDataPointTypeType} representation.
+     * @throws GenDriverException If a general exception occurred.
+     * @throws GenDriverSocketException In case of communication errors with the modbus device.
+     * @throws GenDriverModbusException If the modbus command could not be interpreted/executed on the device.
+     */
+    SGrBasicGenDataPointTypeType[] getValArrByGDPType(String profileName, String dataPointName)
+            throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+
+    /**
+     * Write an array of values to the modbus device. The values are converted from their string
+     * representation to the modbus format as defined within the external interface XML for the given
+     * datapoint.
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint.
+     * @param values The values in their string representation.
+     * @throws GenDriverException If a general exception occurred.
+     * @throws GenDriverSocketException In case of communication errors with the modbus device.
+     * @throws GenDriverModbusException If the modbus command could not be interpreted/executed on the device.
+     */
+    void setValArr(String profileName, String dataPointName, String[] values)
+            throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+
+    /**
+     * Write an array of value to the modbus device. The values are converted from generic datatype
+     * representation to the modbus format as defined within the external interface XML for the given
+     * datapoint.
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint.
+     * @param values The values in their {@link SGrBasicGenDataPointTypeType} representation.
+     * @throws GenDriverException If a general exception occurred.
+     * @throws GenDriverSocketException In case of communication errors with the modbus device.
+     * @throws GenDriverModbusException If the modbus command could not be interpreted/executed on the device.
+     */
+    void setValArrByGDPType(String profileName, String dataPointName, String[] values)
+            throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/api/GenDeviceApi4Rest.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/api/GenDeviceApi4Rest.java
@@ -1,0 +1,78 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package communicator.api;
+
+import communicator.restapi.exception.RestApiAuthenticationException;
+import communicator.restapi.exception.RestApiResponseParseException;
+import communicator.restapi.exception.RestApiServiceCallException;
+
+import java.io.IOException;
+
+public interface GenDeviceApi4Rest {
+
+    /**
+     * Authenticates the REST API client.
+     * Authenticate uses the authentication method and credentials given within the external interface description XML
+     * of the device. The credentials may be given as parameters when loading the {@link communicator.restapi.impl.SGrRestApiDevice}
+     * using the properties parameter of the {@link communicator.helper.DeviceDescriptionLoader}.
+     *
+     * @throws RestApiAuthenticationException If the authentication failed.
+     * @throws IOException If the communication with the server failed.
+     * @throws RestApiServiceCallException If the service call could not be executed on the remote side.
+     * @throws RestApiResponseParseException If parsing of the service response failed.
+     *
+     * @see communicator.restapi.impl.SGrRestApiDevice
+     * @see communicator.helper.DeviceDescriptionLoader
+     */
+    public void authenticate()
+            throws RestApiAuthenticationException, IOException, RestApiServiceCallException, RestApiResponseParseException;
+
+    /**
+     * Reads a value in its string representation from the REST API device.
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint within the functional profile.
+     * @return The value read from the device.
+     * @throws IOException If the communication with the server failed.
+     * @throws RestApiServiceCallException If the service call could not be executed on the remote side.
+     * @throws RestApiResponseParseException If parsing of the service response failed.
+     */
+    public String getVal(String profileName, String dataPointName)
+            throws IOException, RestApiServiceCallException, RestApiResponseParseException;
+
+    /**
+     * Writes a value to the REST API device.
+     * The value may be provided as:
+     * <ul>
+     *     <li>single string value</li>
+     *     <li>http request body on json or XML</li>
+     * </ul>
+     * depending on the value parameter defined in the external interface XML.
+     *
+     * @param profileName The name of the functional profile.
+     * @param dataPointName The name of the datapoint within the functional profile.
+     * @param  value The value to be written. Will replace the value tagged with {@code {{value}}} within the
+     *               external interface {@code <sgr:ServiceCall>} element for the given datapoint.
+     * @throws IOException If the communication with the server failed.
+     * @throws RestApiServiceCallException If the service call could not be executed on the remote side.
+     * @throws RestApiResponseParseException If parsing of the service response failed.
+     */
+    public String setVal(String profileName, String dataPointName, String value)
+            throws IOException, RestApiServiceCallException, RestApiResponseParseException;
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/CacheRecord.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/CacheRecord.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.helper;
 
 import java.time.Instant;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/DeviceDescriptionLoader.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/DeviceDescriptionLoader.java
@@ -2,21 +2,20 @@ package communicator.helper;
 /**
 *Copyright(c) 2022 Verein SmartGridready Switzerland
 * @generated NOT
-* 
+*
 This Open Source Software is BSD 3 clause licensed:
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in 
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
    the documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from 
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
    this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-
  */
 
 import java.io.File;
@@ -39,11 +38,36 @@ import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 public class DeviceDescriptionLoader<C> {
 		
 	private static ComposedAdapterFactory composedAdapterFactory;
-	
+
+	/**
+	 * Load an external device description from its EI-XML file.
+	 *
+	 * @param aBaseDir The path to the folder where the external interface file resides.
+	 * @param aDescriptionFile The external interface file name.
+	 * @return An instance of the device description for the given EI-XML
+	 */
 	public C load( String aBaseDir, String aDescriptionFile) {
 		return load(aBaseDir, aDescriptionFile, null);
 	}
-	
+
+	/**
+	 * Load an external device description from its EI-XML file and replace placeholder
+	 * tags with the values given by the {@code properties} parameter.
+	 * <p>
+	 * Example properties:
+	 * <p>
+	 * <pre>
+	 *   Properties properties = new Properties();
+	 *   properties.put("ipAddress", "127.0.0.1");
+	 *   deviceDescriptionLoader.load( "./EI-XML", "MySGr-Device.xml", properties);
+	 * </pre>
+	 * will replace {@code {{ipAddress}}} within the EI-XML with  the value 127.0.0.1
+	 *
+	 * @param aBaseDir The path to the folder where the external interface file resides.
+	 * @param aDescriptionFile The external interface file name.
+	 * @param properties Key value pairs that replaces tags like {@code {{keyName}}} with the property {@code value}
+	 * @return An instance of the device description for the given EI-XML.
+	 */
 	@SuppressWarnings("unchecked")
 	public C load( String aBaseDir, String aDescriptionFile, Properties properties ) {	
 		

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/GenDriverAPI4ModbusRTUMock.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/GenDriverAPI4ModbusRTUMock.java
@@ -1,23 +1,24 @@
-package communicator.helper;
 /**
-*Copyright(c) 2022 Verein SmartGridready Switzerland
-* @generated NOT
-* 
+ *Copyright(c) 2022 Verein SmartGridready Switzerland
+ * @generated NOT
+ *
 This Open Source Software is BSD 3 clause licensed:
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in 
-   the documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from 
-   this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-
  */
+
+package communicator.helper;
+
 import communicator.common.runtime.GenDriverAPI4Modbus;
 import communicator.common.runtime.GenDriverException;
 

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/GenDriverLoader.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/GenDriverLoader.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.helper;
 
 import communicator.common.runtime.GenDriverAPI4Modbus;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/GenTypeToStringFormatter.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/GenTypeToStringFormatter.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.helper;
 
 import java.math.BigInteger;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/ModbusReader.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/ModbusReader.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.helper;
 
 import com.smartgridready.ns.v0.TEnumObjectType;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/ModbusReaderResponse.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/ModbusReaderResponse.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.helper;
 
 import java.util.Arrays;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/RegisterOrder.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/helper/RegisterOrder.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.helper;
 
 public enum RegisterOrder { LowHigh, HighLow };

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/exception/RestApiAuthenticationException.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/exception/RestApiAuthenticationException.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.exception;
 
 public class RestApiAuthenticationException extends Exception {

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/exception/RestApiResponseParseException.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/exception/RestApiResponseParseException.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.exception;
 
 public class RestApiResponseParseException extends Exception {

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/exception/RestApiServiceCallException.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/exception/RestApiServiceCallException.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.exception;
 
 import org.apache.hc.core5.http.HttpResponse;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/authentication/Authenticator.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/authentication/Authenticator.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.http.authentication;
 
 import java.io.IOException;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/authentication/AuthenticatorFactory.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/authentication/AuthenticatorFactory.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.http.authentication;
 
 import java.lang.reflect.Constructor;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/authentication/BearerTokenAuthenticator.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/authentication/BearerTokenAuthenticator.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.http.authentication;
 
 import java.io.IOException;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/authentication/DummyHttpAuthenticator.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/authentication/DummyHttpAuthenticator.java
@@ -1,3 +1,20 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.http.authentication;
 
 import java.io.IOException;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/ApacheRestServiceClient.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/ApacheRestServiceClient.java
@@ -1,3 +1,20 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package communicator.restapi.http.client;
 
 import java.io.IOException;
@@ -18,6 +35,7 @@ import com.smartgridready.ns.v0.HttpMethod;
 import com.smartgridready.ns.v0.RestServiceCall;
 
 import io.vavr.control.Either;
+
 
 public class ApacheRestServiceClient extends RestServiceClient {
 	

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/ApacheRestServiceClientFactory.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/ApacheRestServiceClientFactory.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.http.client;
 
 import java.util.Properties;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/RestServiceClient.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/RestServiceClient.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.http.client;
 
 import java.io.IOException;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/RestServiceClientFactory.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/RestServiceClientFactory.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.http.client;
 
 import java.util.Properties;

--- a/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/RestServiceClientUtils.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/communicator/restapi/http/client/RestServiceClientUtils.java
@@ -1,3 +1,21 @@
+/**
+Copyright(c) 2022 Verein SmartGridready Switzerland
+
+This Open Source Software is BSD 3 clause licensed:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package communicator.restapi.http.client;
 
 import org.eclipse.emf.common.util.EList;

--- a/InterfaceFactory/CommHandler4Modbus/test/communicator/impl/GetValArrayTester.java
+++ b/InterfaceFactory/CommHandler4Modbus/test/communicator/impl/GetValArrayTester.java
@@ -2,6 +2,7 @@ package communicator.impl;
 
 import java.net.URL;
 
+import communicator.api.GenDeviceApi4Modbus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,7 @@ public class GetValArrayTester {
 			GenDriverAPI4ModbusRTU mbRTU = new GenDriverAPI4ModbusRTU();
 			mbRTU.initTrspService("COM3", 19200);	
 			
-			SGrModbusDevice devWagoMeter = new SGrModbusDevice(tstMeter, mbRTU );				
+			GenDeviceApi4Modbus devWagoMeter = new SGrModbusDevice(tstMeter, mbRTU );
 			
 			try {	
 				// set device address of devWagoMeter

--- a/InterfaceFactory/CommHandler4Modbus/test/communicator/impl/GetValBlockTransferTester.java
+++ b/InterfaceFactory/CommHandler4Modbus/test/communicator/impl/GetValBlockTransferTester.java
@@ -2,6 +2,7 @@ package communicator.impl;
 
 import java.net.URL;
 
+import communicator.api.GenDeviceApi4Modbus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,9 +27,9 @@ public class GetValBlockTransferTester {
 			SGrModbusDeviceFrame tstMeter = loader.load( XML_BASE_DIR, deviceDesc.getPath());
 			
 			GenDriverAPI4ModbusRTU mbRTU = new GenDriverAPI4ModbusRTU();
-			mbRTU.initTrspService("COM3", 19200);	
-			
-			SGrModbusDevice devWagoMeter = new SGrModbusDevice(tstMeter, mbRTU );				
+			mbRTU.initTrspService("COM3", 19200);
+
+			GenDeviceApi4Modbus devWagoMeter = new SGrModbusDevice(tstMeter, mbRTU );
 			
 			try {	
 				// set device address of devWagoMeter

--- a/InterfaceFactory/CommHandler4Modbus/test/communicator/impl/IBTlabLoopTester.java
+++ b/InterfaceFactory/CommHandler4Modbus/test/communicator/impl/IBTlabLoopTester.java
@@ -34,6 +34,7 @@ import com.smartgridready.ns.v0.SGrEnumListType;
 import com.smartgridready.ns.v0.SGrModbusDeviceFrame;
 import com.smartgridready.ns.v0.SGrOCPPStateType;
 import com.smartgridready.ns.v0.SGrBool2BitRankType;
+import communicator.api.GenDeviceApi4Modbus;
 import communicator.common.runtime.Parity;
 import communicator.helper.DeviceDescriptionLoader;
 import de.re.easymodbus.adapter.GenDriverAPI4ModbusRTU;
@@ -52,17 +53,17 @@ public class IBTlabLoopTester {
 	//------------------------------------------------------
 	
 	// Modbus RTU devices
-	private static SGrModbusDevice devWagoMeter = null;
-	private static SGrModbusDevice devABBMeter = null;
-	private static SGrModbusDevice devTB_ABBMeter = null;
+	private static GenDeviceApi4Modbus devWagoMeter = null;
+	private static GenDeviceApi4Modbus devABBMeter = null;
+	private static GenDeviceApi4Modbus devTB_ABBMeter = null;
 	// we need a single driver instance for RTU and separate these by device addres
 	private static GenDriverAPI4ModbusRTU mbRTU = null;
 	
 	// Modbus TCP devices
-	private static SGrModbusDevice devVGT_SGCP = null;
-	private static SGrModbusDevice devGaroWallbox = null;
-	private static SGrModbusDevice devOMCCIWallbox = null;
-	private static SGrModbusDevice devFroniusSymo = null;
+	private static GenDeviceApi4Modbus devVGT_SGCP = null;
+	private static GenDeviceApi4Modbus devGaroWallbox = null;
+	private static GenDeviceApi4Modbus devOMCCIWallbox = null;
+	private static GenDeviceApi4Modbus devFroniusSymo = null;
 	
 	// test loop parameters
 	private static int runtimeCnt = 0;

--- a/InterfaceFactory/CommHandler4Modbus/test/communicator/restapi/impl/ClemapRestApiTest.java
+++ b/InterfaceFactory/CommHandler4Modbus/test/communicator/restapi/impl/ClemapRestApiTest.java
@@ -3,6 +3,7 @@ package communicator.restapi.impl;
 import java.io.IOException;
 import java.util.Properties;
 
+import communicator.api.GenDeviceApi4Rest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,8 +46,8 @@ class ClemapRestApiTest {
 	
 		DeviceDescriptionLoader<SGrRestAPIDeviceFrame> loader = new DeviceDescriptionLoader<>();						
 		
-		SGrRestAPIDeviceFrame clemapDeviceDesc = loader.load(XML_BASE_DIR, "SGr_04_0018_CLEMAP_EIcloudEnergyMonitorV0.2.1.xml", props);	
-		SGrRestApiDevice clemapMonitor =  new SGrRestApiDevice(clemapDeviceDesc, new ApacheRestServiceClientFactory());
+		SGrRestAPIDeviceFrame clemapDeviceDesc = loader.load(XML_BASE_DIR, "SGr_04_0018_CLEMAP_EIcloudEnergyMonitorV0.2.1.xml", props);
+		GenDeviceApi4Rest clemapMonitor =  new SGrRestApiDevice(clemapDeviceDesc, new ApacheRestServiceClientFactory());
  
 		try {
 			clemapMonitor.authenticate();

--- a/InterfaceFactory/CommHandler4Modbus/test/communicator/restapi/impl/SGrRestAPIDeviceTest.java
+++ b/InterfaceFactory/CommHandler4Modbus/test/communicator/restapi/impl/SGrRestAPIDeviceTest.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
+import communicator.api.GenDeviceApi4Rest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.junit.jupiter.api.BeforeAll;
@@ -98,7 +99,7 @@ class SGrRestAPIDeviceTest {
 		when(restServiceClientReq.callService()).thenReturn(Either.right(CLEMAP_METER_RESP));
 		
 		// when
-		SGrRestApiDevice device = new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
+		GenDeviceApi4Rest device = new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
 		device.authenticate();
 		String res = device.getVal("ActivePowerAC", "ActivePowerACtot");
 		
@@ -157,5 +158,4 @@ class SGrRestAPIDeviceTest {
 		// then		
 		assertEquals("6380bbd5200d8506be9b7c10", res);				
 	}
-
 }


### PR DESCRIPTION
- Defined API interface classes for the Modbus and REST API's.
- Added API documentation to the interface classes
- Added SmartGridready copyright headers