### PR TITLE
Fix build.gradle to run with Eclipse

### DIFF
--- a/InterfaceFactory/CommHandler4Modbus/build.gradle
+++ b/InterfaceFactory/CommHandler4Modbus/build.gradle
@@ -32,8 +32,8 @@ sourceSets {
         test.java.srcDirs = ['src/test/java']
         test.resources.srcDirs = ['src/test/resources']
 
-        integrationTest.java.srcDirs = ['src/test/java','src/main/java']
-        integrationTest.resources.srcDirs = ['src/test/resources', 'src/main/resources']
+        integrationTest.java.srcDirs = ['src/test/java']
+        integrationTest.resources.srcDirs = ['src/test/resources']
 }
 
 java {


### PR DESCRIPTION
Fixed a recent change in build.gradle that leads to problems with Eclipse.