### PR TITLE
Improve generic API with device builder and connect/disconnect methods

### DIFF
--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/common/api/GenDeviceApi.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/common/api/GenDeviceApi.java
@@ -61,4 +61,7 @@ public interface GenDeviceApi {
 
     DataPoint getDataPoint(String functionalProfileName, String dataPointName) throws GenDriverException;
 
+    void connect() throws GenDriverException;
+
+    void disconnect() throws GenDriverException;
 }

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/common/api/SGrDeviceBuilder.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/common/api/SGrDeviceBuilder.java
@@ -1,0 +1,226 @@
+package communicator.common.api;
+
+import java.util.Properties;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import com.smartgridready.ns.v0.DeviceFrame;
+import com.smartgridready.ns.v0.InterfaceList;
+import com.smartgridready.ns.v0.ModbusInterfaceDescription;
+
+import communicator.common.api.dto.InterfaceType;
+import communicator.common.helper.DeviceDescriptionLoader;
+import communicator.common.runtime.GenDriverAPI4Modbus;
+import communicator.common.runtime.GenDriverException;
+import communicator.messaging.impl.SGrMessagingDevice;
+import communicator.modbus.api.ModbusGatewayFactory;
+import communicator.modbus.impl.DefaultModbusGatewayFactory;
+import communicator.modbus.impl.SGrModbusDevice;
+import communicator.rest.exception.RestApiAuthenticationException;
+import communicator.rest.http.client.ApacheRestServiceClientFactory;
+import communicator.rest.http.client.RestServiceClientFactory;
+import communicator.rest.impl.SGrRestApiDevice;
+
+/**
+ * Generic SGr device builder.
+ */
+public class SGrDeviceBuilder {
+    
+    private EidSource eidSource;
+    private Properties properties;
+
+    private RestServiceClientFactory restServiceClientFactory;
+    private ModbusGatewayFactory modbusGatewayFactory;
+
+    public SGrDeviceBuilder() {
+        this.eidSource = null;
+        this.properties = null;
+
+        // default implementations
+        this.restServiceClientFactory = new ApacheRestServiceClientFactory();
+        this.modbusGatewayFactory = new DefaultModbusGatewayFactory();
+    }
+
+    /**
+     * Sets the EID source to a file system path.
+     * @param path the file system path
+     * @return the same instance of the builder object
+     */
+    public SGrDeviceBuilder eid(Path path) {
+        this.eidSource = new PathEidSource(path);
+        return this;
+    }
+
+    /**
+     * Sets the EID source to an input stream.
+     * @param inputStream the input stream
+     * @return the same instance of the builder object
+     */
+    public SGrDeviceBuilder eid(InputStream inputStream) {
+        this.eidSource = new StreamEidSource(inputStream);
+        return this;
+    }
+
+    /**
+     * Sets the EID source to XML content.
+     * @param content the XML content
+     * @return the same instance of the builder object
+     */
+    public SGrDeviceBuilder eid(String content) {
+        this.eidSource = new TextEidSource(content);
+        return this;
+    }
+
+    /**
+     * Sets the REST API service client factory.
+     * @param restServiceClientFactory an instance of a REST API service client factory
+     * @return the same instance of the builder object
+     */
+    public SGrDeviceBuilder useRestServiceClientFactory(RestServiceClientFactory restServiceClientFactory) {
+        this.restServiceClientFactory = restServiceClientFactory;
+        return this;
+    }
+
+    /**
+     * Sets the Modbus gateway factory.
+     * @param modbusGatewayFactory an instance of a Modbus gateway factory
+     * @return the same instance of the builder object
+     */
+    public SGrDeviceBuilder useModbusGatewayFactory(ModbusGatewayFactory modbusGatewayFactory) {
+        this.modbusGatewayFactory = modbusGatewayFactory;
+        return this;
+    }
+
+    /**
+     * Sets the EID properties.
+     * @param properties the properties
+     * @return the same instance of the builder object
+     */
+    public SGrDeviceBuilder properties(Properties properties) {
+        this.properties = properties;
+        return this;
+    }
+
+    /**
+     * Builds the SGr device using the previously set builder parameters.
+     * @return an SGr device object
+     * @throws GenDriverException 
+     * @throws RestApiAuthenticationException 
+     */
+    public GenDeviceApi build() throws GenDriverException, RestApiAuthenticationException {
+        if (eidSource == null) {
+            throw new GenDriverException("No EID defined");
+        }
+
+        DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
+        
+        DeviceFrame deviceFrame = eidSource.load(loader, properties);
+        if (deviceFrame == null) {
+            throw new GenDriverException("EID could not be loaded");
+        }
+
+        InterfaceType interfaceType = getInterfaceType(deviceFrame.getInterfaceList());
+        switch (interfaceType) {
+            case MODBUS:
+                if (modbusGatewayFactory == null) {
+                    throw new GenDriverException("No Modbus gateway factory defined");
+                }
+                ModbusInterfaceDescription interfaceDescription = deviceFrame.getInterfaceList().getModbusInterface().getModbusInterfaceDescription();
+                if (interfaceDescription == null) {
+                    throw new GenDriverException("No Modbus interface description defined");
+                }
+                GenDriverAPI4Modbus modbusGateway = modbusGatewayFactory.create(interfaceDescription);
+                return new SGrModbusDevice(deviceFrame, modbusGateway);
+
+            case RESTAPI:
+                if (restServiceClientFactory == null) {
+                    throw new GenDriverException("No REST API service client factory defined");
+                }
+                return new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
+
+            case MESSAGING:
+                return new SGrMessagingDevice(deviceFrame);
+
+            default:
+                throw new GenDriverException(String.format("Unsupported interface type %s", interfaceType));
+        }
+    }
+
+    private static InterfaceType getInterfaceType(InterfaceList interfaceList) {
+
+        if (null != interfaceList.getModbusInterface()) {
+            return InterfaceType.MODBUS;
+        }
+
+        if (null != interfaceList.getRestApiInterface()) {
+            return InterfaceType.RESTAPI;
+        }
+
+        if (null != interfaceList.getMessagingInterface()) {
+            return InterfaceType.MESSAGING;
+        }
+
+        if (null != interfaceList.getContactInterface()) {
+            return InterfaceType.CONTACT;
+        }
+
+        if (null != interfaceList.getGenericInterface()) {
+            return InterfaceType.GENERIC;
+        }
+
+        return InterfaceType.UNKNOWN;
+    }
+
+    /**
+     * An interface for EID data sources.
+     */
+    private static interface EidSource {
+    
+        DeviceFrame load(DeviceDescriptionLoader loader, Properties properties);
+    }
+
+    private static class PathEidSource implements EidSource {
+
+        private Path path;
+
+        public PathEidSource(Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public DeviceFrame load(DeviceDescriptionLoader loader, Properties properties) {
+            String directory = path.getParent().toString();
+            String fileName = path.getFileName().toString();
+            return loader.load(directory, fileName, properties);
+        }
+    }
+
+    private static class StreamEidSource implements EidSource {
+
+        private InputStream inputStream;
+
+        public StreamEidSource(InputStream inputStream) {
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public DeviceFrame load(DeviceDescriptionLoader loader, Properties properties) {
+            return loader.load("eid", inputStream, properties);
+        }
+    }
+
+    private static class TextEidSource implements EidSource {
+
+        private String content;
+
+        public TextEidSource(String content) {
+            this.content = content;
+        }
+
+        @Override
+        public DeviceFrame load(DeviceDescriptionLoader loader, Properties properties) {
+            return loader.load(content, properties);
+        }
+    }
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/common/helper/DeviceDescriptionLoader.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/common/helper/DeviceDescriptionLoader.java
@@ -254,7 +254,7 @@ public class DeviceDescriptionLoader {
 	 * 
 	 * @return a ComposedAdapterFactory
 	 */
-	protected static AdapterFactory getAdapterFactory() {
+	protected synchronized static AdapterFactory getAdapterFactory() {
 		if (composedAdapterFactory == null) {
 			composedAdapterFactory = new ComposedAdapterFactory(
 					ComposedAdapterFactory.Descriptor.Registry.INSTANCE);

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/common/helper/XmlResourceLoader.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/common/helper/XmlResourceLoader.java
@@ -1,0 +1,60 @@
+package communicator.common.helper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+
+public class XmlResourceLoader<T> {
+
+    private static final AdapterFactoryEditingDomain domain;
+
+    static {
+        // XML namespace eNS_URI "http://www.smartgridready.com/ns/V0/" map to "com.smartgridready.ns.v0.V0Package" classes.
+        EPackage.Registry.INSTANCE.put(com.smartgridready.ns.v0.V0Package.eNS_URI, com.smartgridready.ns.v0.V0Package.eINSTANCE);
+
+        // Use XMIResourceFactory to parse *.xml files.
+        Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap()
+            .put("xml", new XMIResourceFactoryImpl());
+
+		AdapterFactory adapterFactory =	new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
+
+        domain = new AdapterFactoryEditingDomain(
+                adapterFactory, 
+                new BasicCommandStack());
+        
+        domain.getResourceSet().setPackageRegistry(EPackage.Registry.INSTANCE);
+    }
+
+    @SuppressWarnings("unchecked")
+    public T load(String resourcePath, String xmlContent, boolean validate) throws IOException {
+        Resource resource = domain.createResource(resourcePath);
+
+		try (InputStream is = IOUtils.toInputStream(xmlContent,  StandardCharsets.UTF_8)) {
+			resource.load(is, null);
+		} catch (IOException e) {
+			// ignore value errors unless validation enabled
+            if (validate) {
+                throw e;
+            }
+		}
+
+        if (!resource.isLoaded()) {
+			throw new IOException(String.format("Resource '%s' could not be loaded", resource.getURI()));
+		}
+
+        T result = (T) resource.getAllContents().next();
+
+		resource.unload();
+
+		return result;
+    }
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/messaging/impl/SGrMessagingDevice.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/messaging/impl/SGrMessagingDevice.java
@@ -41,19 +41,21 @@ public class SGrMessagingDevice extends SGrDeviceBase<
 
     private static final long SYNC_READ_TIMEOUT_MSEC = 60000;
 
-    private final MessagingClient messagingClient;
+    private final MessagingInterfaceDescription interfaceDescription;
+
+    private MessagingClient messagingClient;
 
     private final Map<MessageCacheKey, MessageCacheRecord> messageCache = new HashMap<>();
 
     public SGrMessagingDevice(DeviceFrame deviceDescription) throws GenDriverException {
         super(deviceDescription);
 
-        MessagingInterfaceDescription ifDesc = Optional.ofNullable(deviceDescription.getInterfaceList())
-                .map(InterfaceList::getMessagingInterface)
-                .map(MessagingInterface::getMessagingInterfaceDescription)
-                .orElseThrow(() -> new GenDriverException("Missing messaging interface description in EI-XML"));
+        interfaceDescription = Optional.ofNullable(deviceDescription.getInterfaceList())
+            .map(InterfaceList::getMessagingInterface)
+            .map(MessagingInterface::getMessagingInterfaceDescription)
+            .orElseThrow(() -> new GenDriverException("Missing messaging interface description in EI-XML"));
 
-        messagingClient = MessagingClientFactory.createClient(ifDesc);
+        messagingClient = null;
     }
 
     @Override
@@ -109,6 +111,9 @@ public class SGrMessagingDevice extends SGrDeviceBase<
     }
 
     private Value getValueFromDevice(long timeoutMs, MessagingDataPoint dataPoint, String outMessageTopic, String outMessageTemplate, String inMessageTopic, MessageFilter messageFilter) throws GenDriverException {
+        if (messagingClient == null) {
+            throw new GenDriverException("Not connected");
+        }
 
         Either<Throwable, Message> result = messagingClient.readSync(
                 outMessageTopic,
@@ -147,6 +152,9 @@ public class SGrMessagingDevice extends SGrDeviceBase<
     @Override
     public void setVal(String profileName, String dataPointName, Value value)
             throws GenDriverException {
+        if (messagingClient == null) {
+            throw new GenDriverException("Not connected");
+        }
 
         MessagingDataPoint dataPoint = findDatapoint(profileName, dataPointName);
         checkReadWritePermission(dataPoint, RwpDirections.WRITE);
@@ -169,6 +177,9 @@ public class SGrMessagingDevice extends SGrDeviceBase<
 
     @Override
     public void subscribe(String profileName, String dataPointName, Consumer<Either<Throwable, Value>> callbackFunction) throws GenDriverException {
+        if (messagingClient == null) {
+            throw new GenDriverException("Not connected");
+        }
 
         MessagingDataPoint dataPoint = findDatapoint(profileName, dataPointName);
         checkReadWritePermission(dataPoint, RwpDirections.READ);
@@ -230,6 +241,9 @@ public class SGrMessagingDevice extends SGrDeviceBase<
 
     @Override
     public void unsubscribe(String profileName, String dataPointName) throws GenDriverException {
+        if (messagingClient == null) {
+            throw new GenDriverException("Not connected");
+        }
 
         MessagingDataPoint dataPoint = findDatapoint(profileName, dataPointName);
 
@@ -249,15 +263,17 @@ public class SGrMessagingDevice extends SGrDeviceBase<
     }
 
     @Override
-    public void close() throws IOException {
-        messagingClient.close();
+    public synchronized void close() throws IOException {
+        if (messagingClient != null) {
+            messagingClient.close();
+            messagingClient = null;
+        }
     }
 
     @Override
-	public void connect() throws GenDriverException {
-		// TODO
+	public synchronized void connect() throws GenDriverException {
         if (messagingClient == null) {
-            throw new GenDriverException("No messaging client");
+            messagingClient = MessagingClientFactory.createClient(interfaceDescription);
         }
 	}
 
@@ -267,6 +283,8 @@ public class SGrMessagingDevice extends SGrDeviceBase<
 		    close();
         } catch (IOException e) {
             throw new GenDriverException("Error closing messaging client", e);
+        } finally {
+            messagingClient = null;
         }
 	}
 

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/messaging/impl/SGrMessagingDevice.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/messaging/impl/SGrMessagingDevice.java
@@ -253,6 +253,23 @@ public class SGrMessagingDevice extends SGrDeviceBase<
         messagingClient.close();
     }
 
+    @Override
+	public void connect() throws GenDriverException {
+		// TODO
+        if (messagingClient == null) {
+            throw new GenDriverException("No messaging client");
+        }
+	}
+
+	@Override
+	public void disconnect() throws GenDriverException {
+        try {
+		    close();
+        } catch (IOException e) {
+            throw new GenDriverException("Error closing messaging client", e);
+        }
+	}
+
     private MessagingInterface getMessagingInterface() {
         return Optional.ofNullable(device.getInterfaceList().getMessagingInterface()).orElseThrow(() -> new IllegalArgumentException("No messaging interface defined in EI-XML"));
     }

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/api/ModbusGatewayFactory.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/api/ModbusGatewayFactory.java
@@ -1,0 +1,20 @@
+package communicator.modbus.api;
+
+import com.smartgridready.ns.v0.ModbusInterfaceDescription;
+
+import communicator.common.runtime.GenDriverAPI4Modbus;
+import communicator.common.runtime.GenDriverException;
+
+/**
+ * An interface to create Modbus gateways (or transports).
+ */
+public interface ModbusGatewayFactory {
+    
+    /**
+     * Creates a new Modbus gateway.
+     * @param interfaceDescription the Modbus interface parameters
+     * @return an instance of a Modbus gateway
+     * @throws GenDriverException
+     */
+    GenDriverAPI4Modbus create(ModbusInterfaceDescription interfaceDescription)  throws GenDriverException;
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/helper/ModbusType.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/helper/ModbusType.java
@@ -1,0 +1,7 @@
+package communicator.modbus.helper;
+
+public enum ModbusType {
+    UNKNOWN,
+    RTU,
+    TCP
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/helper/ModbusUtil.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/helper/ModbusUtil.java
@@ -157,4 +157,21 @@ public class ModbusUtil {
 
         return true;
     }
+
+    public static ModbusType getModbusType(ModbusInterfaceDescription interfaceDescription) {
+        String modbusType = interfaceDescription
+                .getModbusInterfaceSelection()
+                .getName();
+
+        switch (modbusType) {
+            case "TCPIP":
+                return ModbusType.TCP;
+
+            case "RTU":
+                return ModbusType.RTU;
+
+            default:
+                return ModbusType.UNKNOWN;
+        }
+    }
 }

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/helper/ModbusUtil.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/helper/ModbusUtil.java
@@ -1,0 +1,160 @@
+package communicator.modbus.helper;
+
+import java.util.Map;
+import java.util.Objects;
+
+import com.smartgridready.ns.v0.ModbusInterfaceDescription;
+import com.smartgridready.ns.v0.ModbusRtu;
+import com.smartgridready.ns.v0.ModbusTcp;
+
+import communicator.common.runtime.DataBits;
+import communicator.common.runtime.GenDriverException;
+import communicator.common.runtime.StopBits;
+import communicator.common.runtime.Parity;
+
+public class ModbusUtil {
+
+    public static final int DEFAULT_MODBUS_TCP_PORT = 502;
+    
+    public static final int DEFAULT_BAUDRATE = 9600;
+    public static final Parity DEFAULT_PARITY = Parity.NONE;
+    public static final DataBits DEFAULT_DATABITS = DataBits.EIGHT;
+    public static final StopBits DEFAULT_STOPBITS = StopBits.ONE;
+
+    public static final short DEFAULT_SLAVE_ID = 0xff;
+    
+    private static final Map<String, DataBits> dataBitMap = Map.of(
+        com.smartgridready.ns.v0.ByteLength._7.getLiteral(), DataBits.SEVEN,
+        com.smartgridready.ns.v0.ByteLength._8.getLiteral(), DataBits.EIGHT
+    );
+    
+    private static final Map<String, StopBits> stopBitMap = Map.of(
+        com.smartgridready.ns.v0.StopBitLength._1.getLiteral(), StopBits.ONE,
+        com.smartgridready.ns.v0.StopBitLength._15.getLiteral(), StopBits.ONE_AND_HALF,
+        com.smartgridready.ns.v0.StopBitLength._2.getLiteral(), StopBits.TWO
+    );
+
+    private static final Map<String, Parity> parityMap = Map.of(
+        com.smartgridready.ns.v0.Parity.NONE.getLiteral(), Parity.NONE,
+        com.smartgridready.ns.v0.Parity.EVEN.getLiteral(), Parity.EVEN,
+        com.smartgridready.ns.v0.Parity.ODD.getLiteral(), Parity.ODD
+    );
+
+    public static boolean isRtuOverSerial(ModbusInterfaceDescription interfaceDescription) {
+        ModbusRtu rtu = interfaceDescription.getModbusRtu();
+        return (
+            (rtu != null) &&
+            (rtu.getPortName() != null) &&
+            !rtu.getPortName().isEmpty()
+        );
+    }
+
+    public static boolean isRtuOverTcp(ModbusInterfaceDescription interfaceDescription) {
+        ModbusTcp tcp = interfaceDescription.getModbusTcp();
+        return (
+            (tcp != null) &&
+            hasValue(tcp.getAddress())
+        );
+    }
+
+    public static Short getModbusSlaveId(ModbusInterfaceDescription interfaceDescription) throws GenDriverException {
+        // distinguish between Serial and TCP
+        boolean isSerial = isRtuOverSerial(interfaceDescription);
+        boolean isTcp = isRtuOverTcp(interfaceDescription);
+        if (isSerial && !isTcp) {
+            ModbusRtu serial = interfaceDescription.getModbusRtu();
+            return hasValue(serial.getSlaveAddr()) ? Short.valueOf(serial.getSlaveAddr()) : DEFAULT_SLAVE_ID;
+        } else if (isTcp && !isSerial) {
+            ModbusTcp tcp = interfaceDescription.getModbusTcp();
+            return hasValue(tcp.getSlaveId()) ? Short.valueOf(tcp.getSlaveId()) : DEFAULT_SLAVE_ID;
+        }
+
+        // cannot be both or none
+        throw new GenDriverException("Could not get slave ID");
+    }
+
+    public static String getModbusGatewayIdentifier(ModbusInterfaceDescription interfaceDescription) throws GenDriverException {
+        // distinguish between Serial and TCP
+        boolean isSerial = isRtuOverSerial(interfaceDescription);
+        boolean isTcp = isRtuOverTcp(interfaceDescription);
+        if (isSerial && !isTcp) {
+            ModbusRtu rtu = interfaceDescription.getModbusRtu();
+            String portName = rtu.getPortName();
+            return String.format("serial:%s", portName);
+        } else if (isTcp && !isSerial) {
+            ModbusTcp tcp = interfaceDescription.getModbusTcp();
+            String address = tcp.getAddress();
+            int port = hasValue(tcp.getPort()) ? Integer.valueOf(tcp.getPort()) : DEFAULT_MODBUS_TCP_PORT;
+            return String.format("tcp:%s:%d", address, port);
+        }
+
+        // cannot be both or none
+        throw new GenDriverException("Could not get Modbus gateway identifier");
+    }
+
+    public static DataBits getSerialDataBits(String dataBits) {
+        return dataBitMap.getOrDefault(dataBits, DEFAULT_DATABITS);
+    }
+
+    public static StopBits getSerialStopBits(String stopBits) {
+        return stopBitMap.getOrDefault(stopBits, DEFAULT_STOPBITS);
+    }
+
+    public static Parity getSerialParity(String parity) {
+        return parityMap.getOrDefault(parity, DEFAULT_PARITY);
+    }
+
+    public static int getSerialBaudrate(String baudRate) {
+        return hasValue(baudRate) ? Integer.valueOf(baudRate) : DEFAULT_BAUDRATE;
+    }
+
+    public static boolean hasValue(String value) {
+        return (
+            (value != null) &&
+            !value.isEmpty()
+        );
+    }
+
+    public static boolean interfaceParametersMatch(ModbusInterfaceDescription interface1, ModbusInterfaceDescription interface2) {
+        if (
+            (null == interface1.getModbusRtu() && null != interface2.getModbusRtu()) ||
+            (null != interface1.getModbusRtu() && null == interface2.getModbusRtu())
+        ) {
+            return false;
+        } else if (null != interface1.getModbusRtu() && null != interface2.getModbusRtu()) {
+            ModbusRtu rtu1 = interface1.getModbusRtu();
+            ModbusRtu rtu2 = interface2.getModbusRtu();
+            if (
+                !(
+                    Objects.equals(rtu1.getPortName(), rtu2.getPortName()) &&
+                    Objects.equals(rtu1.getBaudRateSelected(), rtu2.getBaudRateSelected()) &&
+                    Objects.equals(rtu1.getByteLenSelected(), rtu2.getByteLenSelected()) &&
+                    Objects.equals(rtu1.getParitySelected(), rtu2.getParitySelected()) &&
+                    Objects.equals(rtu1.getStopBitLenSelected(), rtu2.getStopBitLenSelected())
+                )
+            ) {
+                return false;
+            }
+        }
+
+        if (
+            (null == interface1.getModbusTcp() && null != interface2.getModbusTcp()) ||
+            (null != interface1.getModbusTcp() && null == interface2.getModbusTcp())
+        ) {
+            return false;
+        } else if (null != interface1.getModbusTcp() && null != interface2.getModbusTcp()) {
+            ModbusTcp tcp1 = interface1.getModbusTcp();
+            ModbusTcp tcp2 = interface2.getModbusTcp();
+            if (
+                !(
+                    Objects.equals(tcp1.getAddress(), tcp2.getAddress()) &&
+                    Objects.equals(tcp1.getPort(), tcp2.getPort())
+                )
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/DefaultModbusGatewayFactory.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/DefaultModbusGatewayFactory.java
@@ -1,15 +1,11 @@
 package communicator.modbus.impl;
 
 import com.smartgridready.ns.v0.ModbusInterfaceDescription;
-import com.smartgridready.ns.v0.ModbusRtu;
-import com.smartgridready.ns.v0.ModbusTcp;
 
-import communicator.common.runtime.DataBits;
 import communicator.common.runtime.GenDriverAPI4Modbus;
 import communicator.common.runtime.GenDriverException;
-import communicator.common.runtime.Parity;
-import communicator.common.runtime.StopBits;
 import communicator.modbus.api.ModbusGatewayFactory;
+import communicator.modbus.helper.ModbusType;
 import communicator.modbus.helper.ModbusUtil;
 import de.re.easymodbus.adapter.GenDriverAPI4ModbusRTU;
 import de.re.easymodbus.adapter.GenDriverAPI4ModbusTCP;
@@ -20,68 +16,13 @@ public class DefaultModbusGatewayFactory implements ModbusGatewayFactory {
     @Override
     public GenDriverAPI4Modbus create(ModbusInterfaceDescription interfaceDescription) throws GenDriverException {
         // distinguish RTU or TCP protocol
-        ModbusType modbusType = getModbusType(interfaceDescription);
+        ModbusType modbusType = ModbusUtil.getModbusType(interfaceDescription);
         if (modbusType == ModbusType.RTU) {
-            // distinguish between Serial and TCP
-            boolean isSerial = ModbusUtil.isRtuOverSerial(interfaceDescription);
-            boolean isTcp = ModbusUtil.isRtuOverTcp(interfaceDescription);
-            if (isSerial && !isTcp) {
-                // use serial gateway
-                ModbusRtu serial = interfaceDescription.getModbusRtu();
-                String portName = serial.getPortName();
-                int baudrate = ModbusUtil.getSerialBaudrate(serial.getBaudRateSelected());
-                Parity parity = ModbusUtil.getSerialParity(serial.getParitySelected());
-                DataBits dataBits = ModbusUtil.getSerialDataBits(serial.getByteLenSelected());
-                StopBits stopBits = ModbusUtil.getSerialStopBits(serial.getStopBitLenSelected());
-
-                GenDriverAPI4Modbus mbRTU = new GenDriverAPI4ModbusRTU();
-                mbRTU.initTrspService(portName, baudrate, parity, dataBits, stopBits);
-
-                return mbRTU;
-            } else if (isTcp && !isSerial) {
-                // use TCP/IP over RTU gateway
-                ModbusTcp tcp = interfaceDescription.getModbusTcp();
-                String address = tcp.getAddress();
-                int port = ModbusUtil.hasValue(tcp.getPort()) ? Integer.valueOf(tcp.getPort()) : ModbusUtil.DEFAULT_MODBUS_TCP_PORT;
-
-                GenDriverAPI4Modbus mbRTU = new GenDriverAPI4ModbusRTU();
-                mbRTU.initDevice(address, port);
-
-                return mbRTU;
-            }
+            return new GenDriverAPI4ModbusRTU();  
         } else if (modbusType == ModbusType.TCP) {
-            // Modbus TCP
-            ModbusTcp tcp = interfaceDescription.getModbusTcp();
-            if (tcp != null) {
-                String address = tcp.getAddress();
-                int port = ModbusUtil.hasValue(tcp.getPort()) ? Integer.valueOf(tcp.getPort()) : ModbusUtil.DEFAULT_MODBUS_TCP_PORT;
-
-                GenDriverAPI4Modbus mbTCP = new GenDriverAPI4ModbusTCP();
-                mbTCP.initDevice(address, port);
-
-                return mbTCP;
-            }
+            return new GenDriverAPI4ModbusTCP();
         }
 
-        throw new GenDriverException("Could not create Modbus gateway");
-    }
-
-    private static ModbusType getModbusType(ModbusInterfaceDescription interfaceDescription) {
-        String modbusType = interfaceDescription
-                .getModbusInterfaceSelection()
-                .getName();
-        if (modbusType.equals("TCPIP")) {
-            return ModbusType.TCP;
-        } else if (modbusType.equals("RTU")) {
-            return ModbusType.RTU;
-        }
-
-        return ModbusType.UNKNOWN;
-    }
-
-    private static enum ModbusType {
-        UNKNOWN,
-        RTU,
-        TCP
+        throw new GenDriverException(String.format("Unsupported Modbus type %s", modbusType));
     }
 }

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/DefaultModbusGatewayFactory.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/DefaultModbusGatewayFactory.java
@@ -1,0 +1,87 @@
+package communicator.modbus.impl;
+
+import com.smartgridready.ns.v0.ModbusInterfaceDescription;
+import com.smartgridready.ns.v0.ModbusRtu;
+import com.smartgridready.ns.v0.ModbusTcp;
+
+import communicator.common.runtime.DataBits;
+import communicator.common.runtime.GenDriverAPI4Modbus;
+import communicator.common.runtime.GenDriverException;
+import communicator.common.runtime.Parity;
+import communicator.common.runtime.StopBits;
+import communicator.modbus.api.ModbusGatewayFactory;
+import communicator.modbus.helper.ModbusUtil;
+import de.re.easymodbus.adapter.GenDriverAPI4ModbusRTU;
+import de.re.easymodbus.adapter.GenDriverAPI4ModbusTCP;
+
+
+public class DefaultModbusGatewayFactory implements ModbusGatewayFactory {
+
+    @Override
+    public GenDriverAPI4Modbus create(ModbusInterfaceDescription interfaceDescription) throws GenDriverException {
+        // distinguish RTU or TCP protocol
+        ModbusType modbusType = getModbusType(interfaceDescription);
+        if (modbusType == ModbusType.RTU) {
+            // distinguish between Serial and TCP
+            boolean isSerial = ModbusUtil.isRtuOverSerial(interfaceDescription);
+            boolean isTcp = ModbusUtil.isRtuOverTcp(interfaceDescription);
+            if (isSerial && !isTcp) {
+                // use serial gateway
+                ModbusRtu serial = interfaceDescription.getModbusRtu();
+                String portName = serial.getPortName();
+                int baudrate = ModbusUtil.getSerialBaudrate(serial.getBaudRateSelected());
+                Parity parity = ModbusUtil.getSerialParity(serial.getParitySelected());
+                DataBits dataBits = ModbusUtil.getSerialDataBits(serial.getByteLenSelected());
+                StopBits stopBits = ModbusUtil.getSerialStopBits(serial.getStopBitLenSelected());
+
+                GenDriverAPI4Modbus mbRTU = new GenDriverAPI4ModbusRTU();
+                mbRTU.initTrspService(portName, baudrate, parity, dataBits, stopBits);
+
+                return mbRTU;
+            } else if (isTcp && !isSerial) {
+                // use TCP/IP over RTU gateway
+                ModbusTcp tcp = interfaceDescription.getModbusTcp();
+                String address = tcp.getAddress();
+                int port = ModbusUtil.hasValue(tcp.getPort()) ? Integer.valueOf(tcp.getPort()) : ModbusUtil.DEFAULT_MODBUS_TCP_PORT;
+
+                GenDriverAPI4Modbus mbRTU = new GenDriverAPI4ModbusRTU();
+                mbRTU.initDevice(address, port);
+
+                return mbRTU;
+            }
+        } else if (modbusType == ModbusType.TCP) {
+            // Modbus TCP
+            ModbusTcp tcp = interfaceDescription.getModbusTcp();
+            if (tcp != null) {
+                String address = tcp.getAddress();
+                int port = ModbusUtil.hasValue(tcp.getPort()) ? Integer.valueOf(tcp.getPort()) : ModbusUtil.DEFAULT_MODBUS_TCP_PORT;
+
+                GenDriverAPI4Modbus mbTCP = new GenDriverAPI4ModbusTCP();
+                mbTCP.initDevice(address, port);
+
+                return mbTCP;
+            }
+        }
+
+        throw new GenDriverException("Could not create Modbus gateway");
+    }
+
+    private static ModbusType getModbusType(ModbusInterfaceDescription interfaceDescription) {
+        String modbusType = interfaceDescription
+                .getModbusInterfaceSelection()
+                .getName();
+        if (modbusType.equals("TCPIP")) {
+            return ModbusType.TCP;
+        } else if (modbusType.equals("RTU")) {
+            return ModbusType.RTU;
+        }
+
+        return ModbusType.UNKNOWN;
+    }
+
+    private static enum ModbusType {
+        UNKNOWN,
+        RTU,
+        TCP
+    }
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusDevice.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusDevice.java
@@ -97,7 +97,7 @@ public class SGrModbusDevice extends SGrDeviceBase<DeviceFrame, ModbusFunctional
 
 	@Override
 	public void disconnect() throws GenDriverException {
-		drvRegistry.detachGateway(getModbusInterfaceDescription());
+		drv4Modbus.disconnect();
 	}
 
 	@Override

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusDevice.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusDevice.java
@@ -52,6 +52,7 @@ import communicator.common.runtime.GenDriverSocketException;
 import communicator.common.runtime.Parity;
 import communicator.common.runtime.StopBits;
 import communicator.modbus.api.GenDeviceApi4Modbus;
+import communicator.modbus.api.ModbusGatewayFactory;
 import communicator.modbus.helper.CacheRecord;
 import communicator.modbus.helper.ConversionHelper;
 import communicator.modbus.helper.EndiannessConversionHelper;
@@ -96,6 +97,12 @@ public class SGrModbusDevice extends SGrDeviceBase<DeviceFrame, ModbusFunctional
 		super(aDeviceDescription);
 		myDeviceDescription = aDeviceDescription;
 		drv4Modbus = aRtuDriver;
+	}
+
+	public SGrModbusDevice(DeviceFrame aDeviceDescription, ModbusGatewayFactory aGatewayFactory) throws GenDriverException {
+		super(aDeviceDescription);
+		myDeviceDescription = aDeviceDescription;
+		drv4Modbus = aGatewayFactory.create(getModbusInterfaceDescription());
 	}
 
 	@Override

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusDevice.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusDevice.java
@@ -91,6 +91,16 @@ public class SGrModbusDevice extends SGrDeviceBase<DeviceFrame, ModbusFunctional
 	}
 
 	@Override
+	public void connect() throws GenDriverException {
+		// TODO init transport here
+	}
+
+	@Override
+	public void disconnect() throws GenDriverException {
+		drvRegistry.detachGateway(getModbusInterfaceDescription());
+	}
+
+	@Override
 	public Value getVal(String sProfileName, String sDataPointName)
 			throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
 		Optional<ModbusFunctionalProfile> profile = findProfile(sProfileName);

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusDevice.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusDevice.java
@@ -31,6 +31,8 @@ import com.smartgridready.ns.v0.ModbusFunctionalProfile;
 import com.smartgridready.ns.v0.ModbusInterface;
 import com.smartgridready.ns.v0.ModbusInterfaceDescription;
 import com.smartgridready.ns.v0.ModbusLayer6Deviation;
+import com.smartgridready.ns.v0.ModbusRtu;
+import com.smartgridready.ns.v0.ModbusTcp;
 import com.smartgridready.ns.v0.RegisterType;
 import com.smartgridready.ns.v0.ScalingFactor;
 import com.smartgridready.ns.v0.TimeSyncBlockNotification;
@@ -42,16 +44,22 @@ import communicator.common.api.values.NumberValue;
 import communicator.common.api.values.StringValue;
 import communicator.common.api.values.Value;
 import communicator.common.impl.SGrDeviceBase;
+import communicator.common.runtime.DataBits;
 import communicator.common.runtime.GenDriverAPI4Modbus;
 import communicator.common.runtime.GenDriverException;
 import communicator.common.runtime.GenDriverModbusException;
 import communicator.common.runtime.GenDriverSocketException;
+import communicator.common.runtime.Parity;
+import communicator.common.runtime.StopBits;
 import communicator.modbus.api.GenDeviceApi4Modbus;
 import communicator.modbus.helper.CacheRecord;
 import communicator.modbus.helper.ConversionHelper;
 import communicator.modbus.helper.EndiannessConversionHelper;
 import communicator.modbus.helper.ModbusReader;
 import communicator.modbus.helper.ModbusReaderResponse;
+import communicator.modbus.helper.ModbusType;
+import communicator.modbus.helper.ModbusUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +100,41 @@ public class SGrModbusDevice extends SGrDeviceBase<DeviceFrame, ModbusFunctional
 
 	@Override
 	public void connect() throws GenDriverException {
-		// TODO init transport here
+		// distinguish RTU or TCP protocol
+		ModbusInterfaceDescription interfaceDescription = getModbusInterfaceDescription();
+        ModbusType modbusType = ModbusUtil.getModbusType(interfaceDescription);
+        if (modbusType == ModbusType.RTU) {
+            // distinguish between Serial and TCP gateway
+            boolean isSerial = ModbusUtil.isRtuOverSerial(interfaceDescription);
+            boolean isTcp = ModbusUtil.isRtuOverTcp(interfaceDescription);
+            if (isSerial && !isTcp) {
+                // use serial gateway
+                ModbusRtu serial = interfaceDescription.getModbusRtu();
+                String portName = serial.getPortName();
+                int baudrate = ModbusUtil.getSerialBaudrate(serial.getBaudRateSelected());
+                Parity parity = ModbusUtil.getSerialParity(serial.getParitySelected());
+                DataBits dataBits = ModbusUtil.getSerialDataBits(serial.getByteLenSelected());
+                StopBits stopBits = ModbusUtil.getSerialStopBits(serial.getStopBitLenSelected());
+
+                drv4Modbus.initTrspService(portName, baudrate, parity, dataBits, stopBits);
+            } else if (isTcp && !isSerial) {
+                // use TCP/IP over RTU gateway
+                ModbusTcp tcp = interfaceDescription.getModbusTcp();
+                String address = tcp.getAddress();
+                int port = ModbusUtil.hasValue(tcp.getPort()) ? Integer.valueOf(tcp.getPort()) : ModbusUtil.DEFAULT_MODBUS_TCP_PORT;
+
+                drv4Modbus.initDevice(address, port);
+            }
+        } else if (modbusType == ModbusType.TCP) {
+            // Modbus TCP
+            ModbusTcp tcp = interfaceDescription.getModbusTcp();
+            if (tcp != null) {
+                String address = tcp.getAddress();
+                int port = ModbusUtil.hasValue(tcp.getPort()) ? Integer.valueOf(tcp.getPort()) : ModbusUtil.DEFAULT_MODBUS_TCP_PORT;
+
+                drv4Modbus.initDevice(address, port);
+            }
+        }
 	}
 
 	@Override

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/rest/impl/SGrRestApiDevice.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/rest/impl/SGrRestApiDevice.java
@@ -73,8 +73,23 @@ public class SGrRestApiDevice extends SGrDeviceBase<
 
 		RestApiAuthenticationMethod authMethod = getRestApiInterfaceDescription().getRestApiAuthenticationMethod();
 		this.httpAuthenticator = AuthenticatorFactory.getAuthenticator(authMethod);
-	}	
+	}
+
+	@Override
+	public void connect() throws GenDriverException {
+		try {
+		    authenticate();
+        } catch (Exception e) {
+            throw new GenDriverException("Error authenticating", e);
+        }
+	}
+
+	@Override
+	public void disconnect() throws GenDriverException {
+        // nothing
+	}
 	
+	@Override
 	public void authenticate() throws RestApiAuthenticationException, IOException, RestApiServiceCallException, RestApiResponseParseException {
 		httpAuthenticator.getAuthorizationHeaderValue(deviceDescription, restServiceClientFactory);
 	}

--- a/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/common/impl/SGrDeviceBaseTest.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/common/impl/SGrDeviceBaseTest.java
@@ -20,6 +20,7 @@ import communicator.common.api.values.StringValue;
 import communicator.common.api.values.Value;
 import communicator.common.helper.DeviceDescriptionLoader;
 import communicator.common.impl.SGrDeviceBase.Comparator;
+import communicator.common.runtime.GenDriverAPI4Modbus;
 import communicator.common.runtime.GenDriverException;
 import communicator.modbus.impl.SGrModbusDevice;
 import communicator.rest.http.client.ApacheRestServiceClientFactory;
@@ -291,7 +292,7 @@ class SGrDeviceBaseTest {
         DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
         DeviceFrame devDesc = loader.load("", Optional.ofNullable(devDescUrl).map(URL::getPath).orElse(""));
 
-        return new SGrModbusDevice(devDesc, null);
+        return new SGrModbusDevice(devDesc, (GenDriverAPI4Modbus) null);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/messaging/impl/SGrMessagingDeviceTest.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/messaging/impl/SGrMessagingDeviceTest.java
@@ -41,9 +41,13 @@ class SGrMessagingDeviceTest {
 
         try (SGrMessagingDevice msgDevice = createMessagingDevice()) {
 
+            msgDevice.connect();
+
             Value safeCurrent = msgDevice.getVal(FUNCIONAL_PROFILE, "SafeCurrent");
             LOG.info("Safe current read: {}", safeCurrent.getString());
             assertEquals("12 Amperes", safeCurrent.getString());
+
+            msgDevice.disconnect();
         }
     }
 
@@ -51,6 +55,8 @@ class SGrMessagingDeviceTest {
     void setValSynch() throws Exception {
 
         try (SGrMessagingDevice msgDevice = createMessagingDevice()) {
+
+            msgDevice.connect();
 
             // Will be satisfied on callback
             CompletableFuture<Either<Throwable, Value>> future = new CompletableFuture<>();
@@ -68,6 +74,8 @@ class SGrMessagingDeviceTest {
                 assertEquals(expected, result.get().getString());
                 return true;
             });
+
+            msgDevice.disconnect();
         }
     }
 
@@ -75,6 +83,8 @@ class SGrMessagingDeviceTest {
     void subscribe() throws Exception {
 
         try (SGrMessagingDevice msgDevice = createMessagingDevice()) {
+
+            msgDevice.connect();
 
             List<String> safeCurrents = new ArrayList<>();
             List<String> maxReceiveTimes = new ArrayList<>();
@@ -114,6 +124,8 @@ class SGrMessagingDeviceTest {
             Awaitility.await().until(() -> safeCurrents.size()==20 && maxReceiveTimes.size()==20);
             System.out.println(safeCurrents);
             System.out.println(maxReceiveTimes);
+
+            msgDevice.disconnect();
         }
     }
 
@@ -121,6 +133,8 @@ class SGrMessagingDeviceTest {
     void unsubscribe() throws Exception {
 
         try (SGrMessagingDevice msgDevice = createMessagingDevice()) {
+
+            msgDevice.connect();
 
             final SynchronousQueue<Value> resultsMin = new SynchronousQueue<>();
             final SynchronousQueue<Value> resultsMax = new SynchronousQueue<>();
@@ -156,13 +170,17 @@ class SGrMessagingDeviceTest {
 
             assertTrue(ex.getMessage().contains("No value available"));
             assertTrue(ex.getMessage().contains("Try calling subscribe()"));
+
+            msgDevice.disconnect();
         }
     }
 
     @Test
     void getValFromCache() throws Exception {
 
-        try (SGrMessagingDevice msgDevice = createMessagingDevice()){
+        try (SGrMessagingDevice msgDevice = createMessagingDevice()) {
+
+            msgDevice.connect();
 
             final SynchronousQueue<Value> resultsMin = new SynchronousQueue<>();
             final SynchronousQueue<Value> resultsMax = new SynchronousQueue<>();
@@ -200,6 +218,7 @@ class SGrMessagingDeviceTest {
             res = msgDevice.getVal(FUNCIONAL_PROFILE, CHARGING_CURRENT_MAX);
             assertEquals("100", res.getString());
 
+            msgDevice.disconnect();
         }
     }
 

--- a/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/rest/impl/SGrRestAPIDeviceTest.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/rest/impl/SGrRestAPIDeviceTest.java
@@ -104,7 +104,7 @@ class SGrRestAPIDeviceTest {
 		
 		// when
 		GenDeviceApi4Rest device = new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
-		device.authenticate();
+		device.connect();
 		Value res = device.getVal("ActivePowerAC", "ActivePowerACtot");
 		
 		// then		
@@ -129,7 +129,7 @@ class SGrRestAPIDeviceTest {
 		
 		// when
 		SGrRestApiDevice device = new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
-		device.authenticate();
+		device.connect();
 		Value res = device.getVal("ActivePowerAC", "ActivePowerACtot");
 		
 		// then		
@@ -151,7 +151,7 @@ class SGrRestAPIDeviceTest {
 		
 		// when
 		SGrRestApiDevice device = new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
-		device.authenticate();
+		device.connect();
 
 		assertDoesNotThrow(() -> device.setVal("ActivePowerAC", "ActivePowerACtot", Int32UValue.of(100)));
 	}
@@ -170,7 +170,7 @@ class SGrRestAPIDeviceTest {
 		when(restServiceClientAuth.callService()).thenReturn(Either.right(CLEMAP_AUTH_RESP));
 
 		SGrRestApiDevice device = new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
-		device.authenticate();
+		device.connect();
 
 		Exception exception = assertThrows(GenDriverException.class, () -> device.setVal("ActivePowerAC", "ActivePowerACtot", StringValue.of(value)));
 		assertEquals(expectedResponse, exception.getMessage());
@@ -192,9 +192,9 @@ class SGrRestAPIDeviceTest {
 
 	@ParameterizedTest
 	@MethodSource("rwPermissionChecks")
-	void writePermissionCheckModbus(String testName, String dataPointName, boolean isWrite, String expectedErrorMsg) throws Exception {
+	void writePermissionCheckRest(String testName, String dataPointName, boolean isWrite, String expectedErrorMsg) throws Exception {
 
-		LOG.info("Testing writePermissionCheckModbus: {}", testName);
+		LOG.info("Testing writePermissionCheckRest: {}", testName);
 
 		SGrRestApiDevice restApiDevice = new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
 
@@ -222,7 +222,7 @@ class SGrRestAPIDeviceTest {
 	}
 
 	@Test
-	void  unitConversion() throws Exception {
+	void unitConversion() throws Exception {
 
 		SGrRestApiDevice restApiDevice = new SGrRestApiDevice(deviceFrame, restServiceClientFactory);
 


### PR DESCRIPTION
This changes how the generic device API works...

- added generic device builder, like in python implementation
- Modbus transports are created inside the device builder, via a factory
- added connect and disconnect methods to generic device API. these methods actually connect or disconnect the underlying transports. just creating the device instance is not enough.

devices can still be created using the old method, but calling connect/disconnect is mandatory.