### PR TITLE
Support POST form data

### DIFF
--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/rest/impl/SGrRestApiDevice.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/rest/impl/SGrRestApiDevice.java
@@ -28,6 +28,9 @@ import com.smartgridready.ns.v0.RestApiFunctionalProfile;
 import com.smartgridready.ns.v0.RestApiInterface;
 import com.smartgridready.ns.v0.RestApiInterfaceDescription;
 import com.smartgridready.ns.v0.RestApiServiceCall;
+import com.smartgridready.ns.v0.RestApiValueMapping;
+import com.smartgridready.ns.v0.ValueMapping;
+
 import communicator.common.api.values.Float64Value;
 import communicator.common.api.values.StringValue;
 import communicator.common.api.values.Value;
@@ -132,19 +135,25 @@ public class SGrRestApiDevice extends SGrDeviceBase<
 		Properties substitutions = new Properties();
 		if (dpDescriptionOpt.isPresent()) {
 
-			RwpDirections rwpDirection = RwpDirections.READ;
+			RwpDirections rwpDirection = (value != null) ? RwpDirections.WRITE : RwpDirections.READ;
+
+			RestApiDataPointConfiguration dpDescription = dpDescriptionOpt.get();
+			RestApiServiceCall serviceCall = evaluateRestApiServiceCall(dpDescription, rwpDirection);
+
 			if (value != null) {
 				checkOutOfRange(new Value[]{value}, dataPoint);
 				value = applyUnitConversion(dataPoint, value, this::divide);
-				substitutions.put("value", value.getString());
-				rwpDirection = RwpDirections.WRITE;
+
+				// substitute value mappings generic -> device
+				substitutions.put(
+					"value",
+					(serviceCall.getValueMapping() != null) ? getMappedDeviceValue(value.getString(), serviceCall.getValueMapping()) : value.getString()
+				);
 			}
 			if (parameters != null) {
 				substitutions.putAll(parameters);
 			}
 
-			RestApiDataPointConfiguration dpDescription = dpDescriptionOpt.get();
-			RestApiServiceCall serviceCall = evaluateRestApiServiceCall(dpDescription, rwpDirection);
 			RestServiceClient restServiceClient = restServiceClientFactory.create(host, serviceCall, substitutions);
 			String response = handleServiceCall(restServiceClient, httpAuthenticator.isTokenRenewalSupported());
 
@@ -193,8 +202,13 @@ public class SGrRestApiDevice extends SGrDeviceBase<
 				return JsonHelper.mapJsonResponse(responseQuery.getJmesPathMappings(), response);
 			}
 		}
+
 		// return plain response
-		return StringValue.of(response);
+		
+		// substitute value mappings device -> generic
+		return StringValue.of(
+			(restApiServiceCall.getValueMapping() != null) ? getMappedGenericValue(response, restApiServiceCall.getValueMapping()) : response
+		);
 	}
 
 	private RestApiServiceCall evaluateRestApiServiceCall(RestApiDataPointConfiguration dataPointConfiguration, RwpDirections rwpDirections)
@@ -285,5 +299,25 @@ public class SGrRestApiDevice extends SGrDeviceBase<
 
 	private double multiply(double factor1, double factor2) {
 		return  factor1 * factor2;
+	}
+
+	private String getMappedDeviceValue(String genericValue, RestApiValueMapping valueMapping) {
+		for (ValueMapping mapping: valueMapping.getMapping()) {
+			if (genericValue.equals(mapping.getGenericValue())) {
+				return mapping.getDeviceValue();
+			}
+		}
+
+		return genericValue;
+	}
+
+	private String getMappedGenericValue(String deviceValue, RestApiValueMapping valueMapping) {
+		for (ValueMapping mapping: valueMapping.getMapping()) {
+			if (deviceValue.equals(mapping.getDeviceValue())) {
+				return mapping.getGenericValue();
+			}
+		}
+
+		return deviceValue;
 	}
 }

--- a/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/rest/http/client/ApacheRestServiceClientTest.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/rest/http/client/ApacheRestServiceClientTest.java
@@ -1,0 +1,110 @@
+package communicator.rest.http.client;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import org.apache.hc.core5.http.NameValuePair;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ApacheRestServiceClientTest {
+
+    @Test
+	void testFormDataFromBodySuccessNoParams() {
+
+        final String body = "";
+        final Iterable<NameValuePair> params = ApacheRestServiceClient.getFormParameters(body);
+        final Map<String, String> paramMap = toMap(params);
+
+        assertEquals(0, paramMap.size());
+    }
+
+    @Test
+	void testFormDataFromBodySuccessOneParam() {
+
+        final String body = "number=123";
+        final Iterable<NameValuePair> params = ApacheRestServiceClient.getFormParameters(body);
+        final Map<String, String> paramMap = toMap(params);
+
+        assertEquals(1, paramMap.size());
+        assertNotNull(paramMap.get("number"));
+        assertEquals("123", paramMap.get("number"));
+    }
+
+    @Test
+	void testFormDataFromBodySuccessOneParamMultipleAssignmentOperators() {
+
+        final String body = "value=123=3=4";
+        final Iterable<NameValuePair> params = ApacheRestServiceClient.getFormParameters(body);
+        final Map<String, String> paramMap = toMap(params);
+
+        assertEquals(1, paramMap.size());
+        assertNotNull(paramMap.get("value"));
+        assertEquals("123=3=4", paramMap.get("value"));
+    }
+
+    @Test
+	void testFormDataFromBodySuccessMultipleParams() {
+
+        final String body = "number=123&text=hello";
+        final Iterable<NameValuePair> params = ApacheRestServiceClient.getFormParameters(body);
+        final Map<String, String> paramMap = toMap(params);
+
+        assertEquals(2, paramMap.size());
+        assertNotNull(paramMap.get("number"));
+        assertEquals("123", paramMap.get("number"));
+        assertNotNull(paramMap.get("text"));
+        assertEquals("hello", paramMap.get("text"));
+    }
+
+    @Test
+	void testFormDataFromBodySuccessEmptyValue() {
+
+        final String body = "value=123&novalue=";
+        final Iterable<NameValuePair> params = ApacheRestServiceClient.getFormParameters(body);
+        final Map<String, String> paramMap = toMap(params);
+
+        assertEquals(2, paramMap.size());
+        assertNotNull(paramMap.get("value"));
+        assertEquals("123", paramMap.get("value"));
+        assertNotNull(paramMap.get("novalue"));
+        assertEquals("", paramMap.get("novalue"));
+    }
+
+    @Test
+	void testFormDataFromBodyFailNoValue() {
+
+        final String body = "novalue&novalue2";
+        final Iterable<NameValuePair> params = ApacheRestServiceClient.getFormParameters(body);
+        final Map<String, String> paramMap = toMap(params);
+
+        assertEquals(0, paramMap.size());
+    }
+
+    // TODO not sure if this case must be supported
+    @Test
+	void testFormDataFromBodyFailExtraAnd() {
+
+        final String body = "value=abcd&ef&value2=abcd";
+        final Iterable<NameValuePair> params = ApacheRestServiceClient.getFormParameters(body);
+        final Map<String, String> paramMap = toMap(params);
+
+        assertEquals(2, paramMap.size());
+        assertNotNull(paramMap.get("value"));
+        assertNotEquals("abcd&ef", paramMap.get("value"));
+        assertNotNull(paramMap.get("value2"));
+        assertEquals("abcd", paramMap.get("value2"));
+    }
+
+    private static Map<String, String> toMap(Iterable<NameValuePair> params) {
+        Map<String, String> map = new HashMap<>();
+        for (NameValuePair kv: params) {
+            map.put(kv.getName(), kv.getValue());
+        }
+        return map;
+    }
+}

--- a/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/rest/impl/SGrRestAPIDeviceTest.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/test/java/communicator/rest/impl/SGrRestAPIDeviceTest.java
@@ -221,16 +221,18 @@ class SGrRestAPIDeviceTest {
 
 			assertDoesNotThrow(() -> device.setVal("GPIO", dataPointName, StringValue.of("on")));
 
-			verify(httpClientRequest, times(3)).addHeader(stringCaptor1.capture(), stringCaptor2.capture());
+			verify(httpClientRequest, times(4)).addHeader(stringCaptor1.capture(), stringCaptor2.capture());
 			var headerKeys = stringCaptor1.getAllValues();
 			assertEquals("Accept", headerKeys.get(0));
 			assertEquals("Accept", headerKeys.get(1));
-			assertEquals("Authorization", headerKeys.get(2));
+			assertEquals("Accept", headerKeys.get(2));
+			assertEquals("Authorization", headerKeys.get(3));
 
 			var headerValues = stringCaptor2.getAllValues();
 			assertEquals("application/json", headerValues.get(0));
 			assertEquals("application/json", headerValues.get(1));
-			assertEquals("Bearer null", headerValues.get(2));
+			assertEquals("application/json", headerValues.get(2));
+			assertEquals("Bearer null", headerValues.get(3));
 
 			verify(httpClientRequest, times(3)).bodyString(stringCaptor1.capture(), any());
 			assertEquals(

--- a/InterfaceFactory/CommHandler4Modbus/src/test/resources/SGr_04_0018_CLEMAP_EIcloudEnergyMonitorV0.2.1.xml
+++ b/InterfaceFactory/CommHandler4Modbus/src/test/resources/SGr_04_0018_CLEMAP_EIcloudEnergyMonitorV0.2.1.xml
@@ -94,10 +94,6 @@
                       <headerName>Accept</headerName>
                       <value>application/json</value>
                     </header>
-                    <header>
-                      <headerName>Authentication</headerName>
-                      <value>Bearer {{bearerToken}}</value>
-                    </header>
                   </requestHeader>
                   <requestMethod>GET</requestMethod>
                   <requestPath>/digitaltwins/?sensor_id={{sensor_id}}</requestPath>
@@ -240,6 +236,16 @@
               <restApiDataPointConfiguration>
                 <dataType>JSON_boolean</dataType>
                 <restApiWriteServiceCall>
+                  <requestHeader>
+                    <header>
+                      <headerName>Accept</headerName>
+                      <value>application/json</value>
+                    </header>
+                    <header>
+                      <headerName>Content-Type</headerName>
+                      <value>application/json</value>
+                    </header>
+                  </requestHeader>
                   <requestMethod>POST</requestMethod>
                   <requestPath>/digitaltwins/?sensor_id={{sensor_id}}</requestPath>
                   <requestBody>{ "pin" : 1, "value" : "{{value}}" }</requestBody>
@@ -266,6 +272,16 @@
                   </responseQuery>
                 </restApiReadServiceCall>
                 <restApiWriteServiceCall>
+                  <requestHeader>
+                    <header>
+                      <headerName>Accept</headerName>
+                      <value>application/json</value>
+                    </header>
+                    <header>
+                      <headerName>Content-Type</headerName>
+                      <value>application/json</value>
+                    </header>
+                  </requestHeader>
                   <requestMethod>POST</requestMethod>
                   <requestPath>/digitaltwins/?sensor_id={{sensor_id}}&amp;pin=2</requestPath>
                   <requestBody>{ "pin" : 2, "value" : "{{value}}" }</requestBody>

--- a/InterfaceFactory/CommHandler4Modbus/src/test/resources/SGr_05_Swisspower_Dynamic_Tariffs_0.0.1.xml
+++ b/InterfaceFactory/CommHandler4Modbus/src/test/resources/SGr_05_Swisspower_Dynamic_Tariffs_0.0.1.xml
@@ -155,10 +155,6 @@
                       <headerName>Accept</headerName>
                       <value>application/json</value>
                     </header>
-                    <header>
-                      <headerName>Authentication</headerName>
-                      <value>Bearer {{bearerToken}}</value>
-                    </header>
                   </requestHeader>
                   <requestMethod>GET</requestMethod>
                   <requestPath>/api/v1/tariffs?point={{point}}&amp;start_timestamp={{start_timestamp}}&amp;end_timestamp={{end_timestamp}}</requestPath>


### PR DESCRIPTION
Support for HTTP POST requests with form data (content type = application/x-www-form-urlencoded).

This concept uses a request body formatted like the query string and converts it into form parameters.
It still needs optimization!

Note: Just sending the formatted body string and setting the content type header was not sufficient!