### PR TITLE
76 refactoring and removal of legacy functionality

### DIFF
--- a/CommHandler/build.gradle
+++ b/CommHandler/build.gradle
@@ -28,19 +28,23 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-def integrationTest = sourceSets.create('integrationTest')
-
-configurations[integrationTest.implementationConfigurationName].extendsFrom(configurations.testImplementation)
-configurations[integrationTest.runtimeOnlyConfigurationName].extendsFrom(configurations.testRuntimeOnly)
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
 
 sourceSets {
-        main.java.srcDirs = ['src/main/java']
-        main.resources.srcDirs = ['src/main/resources']
-        test.java.srcDirs = ['src/test/java']
-        test.resources.srcDirs = ['src/test/resources']
+    main.java.srcDirs = ['src/main/java']
+    main.resources.srcDirs = ['src/main/resources']
+    test.java.srcDirs = ['src/test/java']
+    test.resources.srcDirs = ['src/test/resources']
 
-        integrationTest.java.srcDirs = ['src/test/java']
-        integrationTest.resources.srcDirs = ['src/test/resources']
+    integrationTest {
+        java.srcDir 'src/test/java'
+        resources.srcDir 'src/test/resources'
+        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
+        runtimeClasspath += output + compileClasspath
+    }
 }
 
 java {
@@ -152,8 +156,8 @@ def integrationTestTask = tasks.register('integrationTest', Test) {
     group = 'verification'
     useJUnitPlatform()
 
-    testClassesDirs = integrationTest.output.classesDirs
-    classpath = configurations[integrationTest.runtimeClasspathConfigurationName] + integrationTest.output
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
 
     setTestNameIncludePatterns(['com.smartgridready.communicator.modbus.integrationtest.*'])
 

--- a/CommHandler/src/main/java/com/smartgridready/communicator/common/api/SGrDeviceBuilder.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/common/api/SGrDeviceBuilder.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 
 import com.smartgridready.communicator.messaging.client.HiveMqtt5MessagingClientFactory;
-import com.smartgridready.driver.api.messaging.MessagingClientFactory;
+import com.smartgridready.driver.api.messaging.GenMessagingClientFactory;
 import com.smartgridready.ns.v0.DeviceFrame;
 import com.smartgridready.ns.v0.InterfaceList;
 import com.smartgridready.ns.v0.ModbusInterfaceDescription;
@@ -34,7 +34,7 @@ public class SGrDeviceBuilder {
 
     private GenHttpRequestFactory httpClientFactory;
     private ModbusGatewayFactory modbusGatewayFactory;
-    private MessagingClientFactory messagingClientFactory;
+    private GenMessagingClientFactory messagingClientFactory;
 
     private ModbusGatewayRegistry modbusGatewayRegistry;
 
@@ -103,7 +103,7 @@ public class SGrDeviceBuilder {
      * Sets the messaging client factory to be used
      * @param messagingClientFactory the messaging client factory to be used
      */
-    public SGrDeviceBuilder useMessagingClientFactory(MessagingClientFactory messagingClientFactory) {
+    public SGrDeviceBuilder useMessagingClientFactory(GenMessagingClientFactory messagingClientFactory) {
         this.messagingClientFactory = messagingClientFactory;
         return this;
     }

--- a/CommHandler/src/main/java/com/smartgridready/communicator/messaging/client/HiveMqtt5MessagingClient.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/messaging/client/HiveMqtt5MessagingClient.java
@@ -13,8 +13,8 @@ import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishResult;
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
 import com.smartgridready.communicator.common.helper.JsonHelper;
+import com.smartgridready.driver.api.messaging.GenMessagingClient;
 import com.smartgridready.driver.api.messaging.Message;
-import com.smartgridready.driver.api.messaging.MessagingClient;
 import com.smartgridready.ns.v0.JMESPathFilterType;
 import com.smartgridready.ns.v0.MessageBrokerAuthentication;
 import com.smartgridready.ns.v0.MessageBrokerAuthenticationBasic;
@@ -42,7 +42,7 @@ import java.util.regex.Pattern;
 
 import static com.hivemq.client.mqtt.MqttGlobalPublishFilter.ALL;
 
-public class HiveMqtt5MessagingClient implements MessagingClient {
+public class HiveMqtt5MessagingClient implements GenMessagingClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(HiveMqtt5MessagingClient.class);
     private static final String MESSAGE_LOG_TEMPLATE ="Received topic={} message={} client={}";
@@ -53,8 +53,7 @@ public class HiveMqtt5MessagingClient implements MessagingClient {
 
     private final Mqtt5AsyncClient asyncClient;
 
-    public HiveMqtt5MessagingClient(MessagingInterfaceDescription messagingInterfaceDesc
-                                      /*Map<MqttClientProperties, String> properties */) {
+    public HiveMqtt5MessagingClient(MessagingInterfaceDescription messagingInterfaceDesc) {
         this.interfaceDescription = messagingInterfaceDesc;
 
         syncClient = createClient().toBlocking();

--- a/CommHandler/src/main/java/com/smartgridready/communicator/messaging/client/HiveMqtt5MessagingClientFactory.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/messaging/client/HiveMqtt5MessagingClientFactory.java
@@ -1,10 +1,10 @@
 package com.smartgridready.communicator.messaging.client;
 
-import com.smartgridready.driver.api.messaging.MessagingClientFactory;
+import com.smartgridready.driver.api.messaging.GenMessagingClientFactory;
 import com.smartgridready.ns.v0.MessagingInterfaceDescription;
 import com.smartgridready.ns.v0.MessagingPlatformType;
 
-public class HiveMqtt5MessagingClientFactory implements MessagingClientFactory {
+public class HiveMqtt5MessagingClientFactory implements GenMessagingClientFactory {
 
     public HiveMqtt5MessagingClient create(MessagingInterfaceDescription interfaceDescription) {
 

--- a/CommHandler/src/main/java/com/smartgridready/communicator/messaging/impl/SGrMessagingDevice.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/messaging/impl/SGrMessagingDevice.java
@@ -1,8 +1,8 @@
 package com.smartgridready.communicator.messaging.impl;
 
 import com.smartgridready.driver.api.messaging.Message;
-import com.smartgridready.driver.api.messaging.MessagingClient;
-import com.smartgridready.driver.api.messaging.MessagingClientFactory;
+import com.smartgridready.driver.api.messaging.GenMessagingClient;
+import com.smartgridready.driver.api.messaging.GenMessagingClientFactory;
 import com.smartgridready.ns.v0.DeviceFrame;
 import com.smartgridready.ns.v0.InMessage;
 import com.smartgridready.ns.v0.InterfaceList;
@@ -45,14 +45,14 @@ public class SGrMessagingDevice extends SGrDeviceBase<
 
     private final MessagingInterfaceDescription interfaceDescription;
 
-    private final MessagingClientFactory messagingClientFactory;
+    private final GenMessagingClientFactory messagingClientFactory;
 
-    private MessagingClient messagingClient;
+    private GenMessagingClient messagingClient;
 
     private final Map<MessageCacheKey, MessageCacheRecord> messageCache = new HashMap<>();
 
     public SGrMessagingDevice(DeviceFrame deviceDescription,
-                              MessagingClientFactory messagingClientFactory) throws GenDriverException {
+                              GenMessagingClientFactory messagingClientFactory) throws GenDriverException {
         super(deviceDescription);
 
         interfaceDescription = Optional.ofNullable(deviceDescription.getInterfaceList())

--- a/CommHandler/src/test/java/com/smartgridready/communicator/async/AsyncClemapWagoTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/async/AsyncClemapWagoTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class AsyncClemapWagoTest {
     public static final Logger LOG = LoggerFactory.getLogger(AsyncClemapWagoTest.class);
 
-    private static final String XML_BASE_DIR = "../../../SGrSpecifications/XMLInstances/ExtInterfaces/";
+    private static final String XML_BASE_DIR = "../../SGrSpecifications/XMLInstances/ExtInterfaces";
 
     private static SGrModbusDevice wagoDevice;
 
@@ -154,7 +154,7 @@ public class AsyncClemapWagoTest {
         props.put("sensor_id", "63343431ecf2cf013a1e5a9f");
 
         DeviceFrame deviceDesc = new DeviceDescriptionLoader()
-                .load(XML_BASE_DIR, "SGr_04_0018_CLEMAP_EIcloudEnergyMonitorV0.2.1.xml", props);
+                .load(XML_BASE_DIR, "SGr_02_0018_CLEMAP_EIcloudEnergyMonitor_V1.0.0.xml", props);
 
         SGrRestApiDevice clemapDevice = new SGrRestApiDevice(deviceDesc, new ApacheHttpRequestFactory());
         clemapDevice.authenticate();

--- a/CommHandler/src/test/java/com/smartgridready/communicator/messaging/client/Mqtt5MessagingClientTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/messaging/client/Mqtt5MessagingClientTest.java
@@ -1,7 +1,7 @@
 package com.smartgridready.communicator.messaging.client;
 
 import com.smartgridready.driver.api.messaging.Message;
-import com.smartgridready.driver.api.messaging.MessagingClient;
+import com.smartgridready.driver.api.messaging.GenMessagingClient;
 import com.smartgridready.ns.v0.JMESPathFilterType;
 import com.smartgridready.ns.v0.MessageFilter;
 import com.smartgridready.ns.v0.MessagingInterfaceDescription;
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class Mqtt5MessagingClientTest {
+class Mqtt5GenMessagingClientTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(HiveMqtt5MessagingClient.class);
 
@@ -47,7 +47,7 @@ class Mqtt5MessagingClientTest {
     @Test
     void sendReceiveSync() throws Exception {
 
-        try (MessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
+        try (GenMessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
 
             // Set up a thread with a blocking receiver for the message.
             Either<Throwable, Message> result = client.readSync(
@@ -64,7 +64,7 @@ class Mqtt5MessagingClientTest {
     @Test
     void sendReceiveSyncWithTopicFilter() throws Exception{
 
-       try (MessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
+       try (GenMessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
 
            CompletableFuture<Either<Throwable, Message>> asyncMsgSender1 = CompletableFuture.supplyAsync(() ->
                    client.readSync(TEST_TOPIC, Message.of("50K"), TEST_TOPIC, null, 2000));
@@ -86,7 +86,7 @@ class Mqtt5MessagingClientTest {
     @Test
     void sendReceiveSyncWithMessageFilter() throws Exception {
 
-        try (MessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
+        try (GenMessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
 
             MessageFilter messageFilter1 = createMessageFilter("1");
             MessageFilter messageFilter2 = createMessageFilter("2");
@@ -125,7 +125,7 @@ class Mqtt5MessagingClientTest {
     @Test
     void sendAndReceiveSyncTimeout() throws Exception {
 
-        try (MessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
+        try (GenMessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
 
             Either<Throwable, Message> future = client.readSync(TEST_TOPIC, Message.of("50K"), TEST_TOPIC_2, null, 1000);
             // no message sent to topic
@@ -136,7 +136,7 @@ class Mqtt5MessagingClientTest {
     @Test
     void sendAndReceiveSyncUnsupportedFilter() throws Exception {
 
-        try (MessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
+        try (GenMessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
             MessageFilter messageFilter = V0Factory.eINSTANCE.createMessageFilter();
             XPathFilterType xPathFilter = V0Factory.eINSTANCE.createXPathFilterType();
             messageFilter.setXpapathFilter(xPathFilter);
@@ -175,7 +175,7 @@ class Mqtt5MessagingClientTest {
     @Test
     void sendReceiveAsynchWithMessageFilter() throws Exception {
 
-        try (MessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
+        try (GenMessagingClient client = new HiveMqtt5MessagingClient(createMessagingInterfaceDescription())) {
 
             MessageFilter messageFilter1 = createMessageFilter("1");
             MessageFilter messageFilter2 = createMessageFilter("2");

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IntrospectiveDeviceTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IntrospectiveDeviceTester.java
@@ -21,7 +21,7 @@ public class IntrospectiveDeviceTester {
 
     private static final Logger LOG = LoggerFactory.getLogger(GetValArrayTester.class);
 
-    private static final String XML_BASE_DIR="../../../SGrSpecifications/XMLInstances/ExtInterfaces/";
+    private static final String XML_BASE_DIR="../../SGrSpecifications/XMLInstances/ExtInterfaces/";
 
     private static final class ProtocolRecord {
         String fpName;
@@ -90,29 +90,29 @@ public class IntrospectiveDeviceTester {
         }
         catch ( Exception e )
         {
-            LOG.error( "Error loading device description. " + e);
+            LOG.error( "Error loading device description.", e);
         }
     }
 
     private static ProtocolRecord checkDataPoint(Tuple3<String,String, Properties> dataPoint, SGrDeviceBase<?, ?, ?> device) {
 
-        ProtocolRecord record = new ProtocolRecord();
-        record.readVal = "-";
-        record.exception = "";
-        record.fpName = dataPoint._1;
-        record.dpName = dataPoint._2;
+        ProtocolRecord protocolRecord = new ProtocolRecord();
+        protocolRecord.readVal = "-";
+        protocolRecord.exception = "";
+        protocolRecord.fpName = dataPoint._1;
+        protocolRecord.dpName = dataPoint._2;
 
         try {
             if (dataPoint._3 != null) {
                 SGrRestApiDevice restApiDevice = (SGrRestApiDevice) device;
-                record.readVal = restApiDevice.getVal(dataPoint._1, dataPoint._2, dataPoint._3).getString();
+                protocolRecord.readVal = restApiDevice.getVal(dataPoint._1, dataPoint._2, dataPoint._3).getString();
             } else {
-                record.readVal = device.getVal(dataPoint._1, dataPoint._2).getString();
+                protocolRecord.readVal = device.getVal(dataPoint._1, dataPoint._2).getString();
             }
         } catch (Exception e) {
-            record.exception = e.getMessage();
+            protocolRecord.exception = e.getMessage();
         }
-        return record;
+        return protocolRecord;
     }
 
     private static Tuple3<DeviceFrame, SGrDeviceBase<?, ?, ?>, Properties> createWagoDevice() throws Exception {


### PR DESCRIPTION
- Renamed MessagingClient to GenMessagingClient and MessagingClientFactory to GenMessagingClientFactory. Aligns the naming pattern with the API's for modbus and http.
- Fixed changed base path due to refactorings for EI-XML loaded from SGrSpecification.
- Fixed CommHandler build.gradle: integrationTest did not compile after refactoring.