### PR TITLE
Fixes Modbus RTU in v1.1.x release

### DIFF
--- a/InterfaceFactory/CommHandler4Modbus/build.gradle
+++ b/InterfaceFactory/CommHandler4Modbus/build.gradle
@@ -15,6 +15,13 @@ repositories {
     mavenLocal()
     mavenCentral()
     gradlePluginPortal()
+
+    maven {
+        url "https://nexus.library.smartgridready.ch/repository/maven-releases/"
+    }
+    maven {
+        url "https://nexus.library.smartgridready.ch/repository/maven-snapshots/"
+    }
 }
 
 

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/GenDriverAPI4ModbusRTUWrapper.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/GenDriverAPI4ModbusRTUWrapper.java
@@ -18,10 +18,7 @@ class GenDriverAPI4ModbusRTUWrapper extends GenDriverAPI4ModbusRTU implements Ge
     private DataBits dataBits;
     private StopBits stopBits;
 
-    private String tcpAddress;
-    private int tcpPort;
-
-    public GenDriverAPI4ModbusRTUWrapper(String serialPort, int baudRate, Parity parity, DataBits dataBits, StopBits stopBits, String tcpAddress, int tcpPort) {
+    public GenDriverAPI4ModbusRTUWrapper(String serialPort, int baudRate, Parity parity, DataBits dataBits, StopBits stopBits) {
         super();
         isConnected = false;
         this.serialPort = serialPort;
@@ -29,17 +26,11 @@ class GenDriverAPI4ModbusRTUWrapper extends GenDriverAPI4ModbusRTU implements Ge
         this.parity = parity;
         this.dataBits = dataBits;
         this.stopBits = stopBits;
-        this.tcpAddress = tcpAddress;
-        this.tcpPort = tcpPort;
     }
 
     @Override
     public boolean connect() throws GenDriverException {
-        if (StringUtil.isNotEmpty(tcpAddress)) {
-            // use RTU over TCP/IP gateway
-            this.initDevice(tcpAddress, tcpPort);
-            isConnected = true;
-        } else if (StringUtil.isNotEmpty(serialPort)) {
+        if (StringUtil.isNotEmpty(serialPort)) {
             // use serial RTU gateway
             isConnected = this.initTrspService(serialPort, baudrate, parity, dataBits, stopBits);
         } else {

--- a/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusGatewayFactory.java
+++ b/InterfaceFactory/CommHandler4Modbus/src/main/java/communicator/modbus/impl/SGrModbusGatewayFactory.java
@@ -24,7 +24,7 @@ public class SGrModbusGatewayFactory implements ModbusGatewayFactory {
         GenDriverAPI4ModbusConnectable transport;
         switch (modbusType) {
             case RTU:
-                transport = createRTUTransport(interfaceDescription.getModbusRtu(), interfaceDescription.getModbusTcp());
+                transport = createRTUTransport(interfaceDescription.getModbusRtu());
                 break;
  
             case TCP:
@@ -39,17 +39,14 @@ public class SGrModbusGatewayFactory implements ModbusGatewayFactory {
         return new ModbusGateway(identifier, interfaceDescription, transport);
     }
 
-    private GenDriverAPI4ModbusConnectable createRTUTransport(ModbusRtu rtu, ModbusTcp tcp) {
+    private GenDriverAPI4ModbusConnectable createRTUTransport(ModbusRtu rtu) {
         String serialPort = rtu.getPortName();
         int baudrate = ModbusUtil.getSerialBaudrate(rtu.getBaudRateSelected());
         Parity parity = ModbusUtil.getSerialParity(rtu.getParitySelected());
         DataBits dataBits = ModbusUtil.getSerialDataBits(rtu.getByteLenSelected());
         StopBits stopBits = ModbusUtil.getSerialStopBits(rtu.getStopBitLenSelected());
 
-        String tcpAddress = tcp.getAddress();
-        int tcpPort = ModbusUtil.isNonEmptyString(tcp.getPort()) ? Integer.valueOf(tcp.getPort()) : ModbusUtil.DEFAULT_MODBUS_TCP_PORT;
-
-        return new GenDriverAPI4ModbusRTUWrapper(serialPort, baudrate, parity, dataBits, stopBits, tcpAddress, tcpPort);
+        return new GenDriverAPI4ModbusRTUWrapper(serialPort, baudrate, parity, dataBits, stopBits);
     }
 
     private GenDriverAPI4ModbusConnectable createTCPTransport(ModbusTcp tcp) {

--- a/InterfaceFactory/CommHandler4Modbus/src/test/resources/devicedescriptions.yaml
+++ b/InterfaceFactory/CommHandler4Modbus/src/test/resources/devicedescriptions.yaml
@@ -12,7 +12,8 @@ descriptions:
 -   file: SGr_04_0005_xxxx_GARO_WallboxV0.2.1.xml
 -   file: SGr_04_0014_0000_WAGO_SmartMeterV0.2.1.xml
 -   file: SGr_04_0015_xxxx_StiebelEltron_HeatPumpV0.2.1.xml
--   file: SGr_04_0016_xxxx_ABBMeterV0.2.1.xml
+-   file: SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml
+-   file: SGr_00_0016_dddd_ABB_B23_ModbusTCP_V0.3.xml
 -   file: SGr_04_0017_xxxx_HOVAL_HeatPumpV0.2.1.xml
 -   file: SGr_04_0019_0059_VGT_SPSDeviceforHomeAutomation_v0.2.1.xml
 -   file: SGr_04_0020_xxxx_Heliotherm_HeatPumpV0.2.1.xml
@@ -26,4 +27,3 @@ descriptions:
 -   file: SontexSupercal5V0.2.1.xml
 -   file: abb_terra_01.xml
 -   file: mvpEi4Modbus_0000_0036_0030_4_0.1_SGCP_BiDirFlexMgmt.xml
-  

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,16 @@ java {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
+    gradlePluginPortal()
+
+    maven {
+        url "https://nexus.library.smartgridready.ch/repository/maven-releases/"
+    }
+    maven {
+        url "https://nexus.library.smartgridready.ch/repository/maven-snapshots/"
+    }
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
- Modbus device can be either RTU or TCP, no more "RTU over TCP" (as discussed before)
- fixes error when using current EID specification in combination with 1.1.0
- added Nexus to Gradle repositories (backport from master)