### PR TITLE
Fix HTTP Form Parameter, remove headers with NULL value

### DIFF
--- a/CommHandler/src/main/java/com/smartgridready/communicator/messaging/impl/SGrMessagingDevice.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/messaging/impl/SGrMessagingDevice.java
@@ -180,7 +180,7 @@ public class SGrMessagingDevice extends SGrDeviceBase<
                 .orElseThrow(() -> new IllegalArgumentException("W and RW data-points need an outMessageTemplate to send the read command within EI-XML"));
 
         // noinspection RegExpRedundantEscape
-        outMessageTemplate = outMessageTemplate.replace("[[value]]", value.getString());
+        outMessageTemplate = outMessageTemplate.replace("{{value}}", value.getString());
 
         messagingClient.sendSync(outMessageTopic, Message.of(outMessageTemplate));
     }

--- a/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/ApacheHttpRequest.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/ApacheHttpRequest.java
@@ -18,12 +18,13 @@ import org.apache.hc.core5.http.message.BasicNameValuePair;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ApacheHttpRequest implements GenHttpRequest {
 
@@ -64,11 +65,13 @@ public class ApacheHttpRequest implements GenHttpRequest {
         ContentType requestContentType = prepareHttpHeaders(httpReq);
 
         if (!formParams.isEmpty()) {
-            final List<NameValuePair> nameValuePairList = new ArrayList<>();
-            formParams.forEach((key, value) -> nameValuePairList.add(new BasicNameValuePair(key, value)));
-            httpReq.body(new UrlEncodedFormEntity(nameValuePairList));
+            final List<NameValuePair> nameValuePairList = formParams
+                .entrySet()
+                .stream()
+                .map(e -> new BasicNameValuePair(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+            httpReq.body(new UrlEncodedFormEntity(nameValuePairList, StandardCharsets.UTF_8));
         } else if (body != null) {
-
             Function31<Request, String, ContentType, Request> bodyEncodeFunct = BODY_ENCODE_MAP.get(requestContentType.getMimeType());
             if (bodyEncodeFunct == null) {
                 throw new IOException(String.format("Cannot encode request body of content type '%s'", requestContentType.getMimeType()));

--- a/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/RestServiceClient.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/RestServiceClient.java
@@ -63,11 +63,12 @@ public class RestServiceClient {
 	}
 
 	public void addHeader(String key, String value) {
-
-		HeaderEntry headerEntry = new HeaderEntry();
-		headerEntry.setHeaderName(key);
-		headerEntry.setValue(value);
-		restServiceCall.getRequestHeader().getHeader().add(headerEntry);
+		if (value != null) {
+			HeaderEntry headerEntry = new HeaderEntry();
+			headerEntry.setHeaderName(key);
+			headerEntry.setValue(value);
+			restServiceCall.getRequestHeader().getHeader().add(headerEntry);
+		}
 	}
 
 	public String getBaseUri() {

--- a/CommHandler/src/test/resources/SGr_XX_HiveMQ_MQTT_Cloud.xml
+++ b/CommHandler/src/test/resources/SGr_XX_HiveMQ_MQTT_Cloud.xml
@@ -99,7 +99,7 @@
                 </readCmdMessage>
                 <writeCmdMessage>
                   <topic>stations/1/safecurrent/limit</topic>
-                  <template>[[value]]</template>
+                  <template>{{value}}</template>
                 </writeCmdMessage>
                 <inMessage>
                   <topic>stations/1/safecurrent/limit</topic>
@@ -135,7 +135,7 @@
                 </readCmdMessage>
                 <writeCmdMessage>
                   <topic>stations/1/max_receive_time</topic>
-                  <template>[[value]]</template>
+                  <template>{{value}}</template>
                 </writeCmdMessage>
                 <inMessage>
                   <topic>stations/1/max_receive_time</topic>
@@ -158,7 +158,7 @@
                 <writeCmdMessage>
                   <!-- The datapoint needs to be writable for tests -->
                   <topic>stations/1/charging_current</topic>
-                  <template>[[value]]</template>
+                  <template>{{value}}</template>
                 </writeCmdMessage>
                 <inMessage>
                   <topic>stations/1/charging_current</topic>
@@ -191,7 +191,7 @@
                 <writeCmdMessage>
                   <!-- The datapoint needs to be writable for tests -->
                   <topic>stations/1/charging_current</topic>
-                  <template>[[value]]</template>
+                  <template>{{value}}</template>
                 </writeCmdMessage>
                 <inMessage>
                   <topic>stations/1/charging_current</topic>


### PR DESCRIPTION
- form parameters encoded with UTF-8
- headers with NULL value no longer added
- fixed write template of messaging --> use `{{value}}` placeholder