### PR TITLE
Avoid HTTP Authorization headers with null value.

### DIFF
--- a/CommHandler/src/main/java/com/smartgridready/communicator/common/helper/JsonHelper.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/common/helper/JsonHelper.java
@@ -3,6 +3,8 @@ package com.smartgridready.communicator.common.helper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.smartgridready.ns.v0.JMESPathMapping;
 import com.smartgridready.ns.v0.JMESPathMappingRecord;
 import com.smartgridready.communicator.common.api.values.StringValue;
@@ -43,6 +45,15 @@ public class JsonHelper {
         try {
             JsonNode jsonNode = mapper.readTree(jsonResp);
             JsonNode res = expression.search(jsonNode);
+
+            // complex nodes: return the result as JSON string
+            if (res instanceof ObjectNode) {
+                return StringValue.of(res.toString());
+            }
+            if (res instanceof ArrayNode) {
+                return StringValue.of(res.toString());
+            }
+
             return StringValue.of(res.asText());
         } catch (IOException e) {
             throw new GenDriverException("Failed to parse JSON response", e);

--- a/CommHandler/src/main/java/com/smartgridready/communicator/rest/impl/SGrRestApiDevice.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/rest/impl/SGrRestApiDevice.java
@@ -168,9 +168,11 @@ public class SGrRestApiDevice extends SGrDeviceBase<
 	}	
 
 	private String handleServiceCall(RestServiceClient serviceClient, boolean tryTokenRenewal) throws IOException, RestApiServiceCallException, RestApiResponseParseException {
-		
-		serviceClient.addHeader(HttpHeaders.AUTHORIZATION,
-				httpAuthenticator.getAuthorizationHeaderValue(deviceDescription, httpRequestFactory));
+
+		if (httpAuthenticator.getAuthorizationHeaderValue(deviceDescription, httpRequestFactory) != null) {
+			serviceClient.addHeader(HttpHeaders.AUTHORIZATION,
+					httpAuthenticator.getAuthorizationHeaderValue(deviceDescription, httpRequestFactory));
+		}
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Calling REST service: {} - {}", 

--- a/CommHandler/src/test/java/com/smartgridready/communicator/rest/impl/TariffProvidersTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/rest/impl/TariffProvidersTest.java
@@ -1,0 +1,64 @@
+package com.smartgridready.communicator.rest.impl;
+
+import com.smartgridready.communicator.common.api.SGrDeviceBuilder;
+import com.smartgridready.communicator.rest.http.client.ApacheHttpRequestFactory;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Disabled("uses real tariff providers, might be unstable")
+class TariffProvidersTest {
+
+    static final Logger LOG = LoggerFactory.getLogger(TariffProvidersTest.class);
+
+    private static final String XML_BASE_DIR="../../SGrSpecifications/XMLInstances/ExtInterfaces/";
+
+    @Test
+    void testSwisspower() throws Exception {
+
+        var properties = new Properties();
+        properties.put("token", "19d6ca0bb9bf4d8b6525440eead80da6");
+        properties.put("start_timestamp", "2024-01-01T00:00:00+02:00");
+        properties.put("end_timestamp", "2024-01-01T01:00:00+02:00");
+        properties.put("metering_code", "CH1018601234500000000000000011642");
+
+        var device = new SGrDeviceBuilder()
+                .useRestServiceClientFactory(new ApacheHttpRequestFactory())
+                .eid(Path.of(XML_BASE_DIR + "SGr_05_mmmm_dddd_Dynamic_Tariffs_Swisspower_V0.0.1.xml"))
+                .properties(properties)
+                .build();
+
+        var result = device.getVal("DynamicTariff", "TariffSupply");
+        LOG.info(result.getString());
+
+        String expected = "[{\"start_timestamp\":\"2024-01-01T00:00:00";
+        assertThat(result.getString(), CoreMatchers.startsWith(expected));
+    }
+
+    @Test
+    void testGroupeE() throws Exception {
+
+        var properties = new Properties();
+        properties.put("start_timestamp", "2024-01-01T00:00:00+02:00");
+        properties.put("end_timestamp", "2024-01-02T00:00:00+02:00");
+
+        var device = new SGrDeviceBuilder()
+                .useRestServiceClientFactory(new ApacheHttpRequestFactory())
+                .eid(Path.of(XML_BASE_DIR + "SGr_05_mmmm_dddd_Dynamic_Tariffs_GroupeE_V0.0.1.xml"))
+                .properties(properties)
+                .build();
+
+        var result = device.getVal("DynamicTariff", "TariffSupply");
+        LOG.info(result.getString());
+
+        assertThat(result.getString(),
+                CoreMatchers.startsWith("[{\"start_timestamp\":\"2023-12-31T23:00:00"));
+    }
+}


### PR DESCRIPTION
Avoid HTTP Authorization headers with null value.
Handle JMES-path query results that return complex objects properly.