### PR TITLE
Dev build args

### DIFF
--- a/CommHandler/build.gradle
+++ b/CommHandler/build.gradle
@@ -6,7 +6,7 @@
  */
 
 plugins {
-    id 'java'
+    id 'java-library'
     id 'maven-publish'
 }
 
@@ -51,12 +51,9 @@ test {
     useJUnitPlatform() // needed to run JUnit 5 test with gradle
 }
 
-configurations {
-    extraLibs.extendsFrom implementation
-}
-
 // allow snapshot dependencies when explicitly requested, use release versions by default
-def sgr_spec_suffix = ''
+// spec. release date
+def sgr_spec_suffix = '_2024-10-08'
 def sgr_driver_suffix = ''
 def sgr_modbus_suffix = ''
 
@@ -72,11 +69,10 @@ if (project.hasProperty("sgr-modbus-dev")) {
 
 
 dependencies {
-    implementation group: 'com.smartgridready', name: 'sgr-specification', version: "2.0_2024-10-08${sgr_spec_suffix}"
-    implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '4.0.2'
+    api group: 'com.smartgridready', name: 'sgr-specification', version: "2.0${sgr_spec_suffix}"
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
 
-    implementation group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.0.0${sgr_driver_suffix}"
+    api group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.0.0${sgr_driver_suffix}"
     implementation group: 'com.smartgridready', name: 'easymodbus', version: "2.0.0${sgr_modbus_suffix}"
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.1.3'
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5-fluent', version: '5.1.3'
@@ -87,7 +83,7 @@ dependencies {
     implementation group: 'io.burt', name: 'jmespath-jackson', version: '0.5.1'
     implementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
-    implementation group: 'io.vavr', name: 'vavr', version: '0.10.4'
+    api group: 'io.vavr', name: 'vavr', version: '0.10.5'
 
     implementation group: 'io.reactivex.rxjava3', name: 'rxjava', version: '3.1.5'
 

--- a/CommHandler/build.gradle
+++ b/CommHandler/build.gradle
@@ -15,7 +15,6 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 
-
     maven {
         url "https://nexus.library.smartgridready.ch/repository/maven-releases/"
     }
@@ -23,9 +22,6 @@ repositories {
         url "https://nexus.library.smartgridready.ch/repository/maven-snapshots/"
     }
 }
-
-apply plugin: 'java'
-apply plugin: 'maven-publish'
 
 configurations {
     integrationTestImplementation.extendsFrom testImplementation
@@ -59,13 +55,29 @@ configurations {
     extraLibs.extendsFrom implementation
 }
 
+// allow snapshot dependencies when explicitly requested, use release versions by default
+def sgr_spec_suffix = ''
+def sgr_driver_suffix = ''
+def sgr_modbus_suffix = ''
+
+if (project.hasProperty("sgr-spec-dev")) {
+    sgr_spec_suffix = '-SNAPSHOT'
+}
+if (project.hasProperty("sgr-driver-dev")) {
+    sgr_driver_suffix = '-SNAPSHOT'
+}
+if (project.hasProperty("sgr-modbus-dev")) {
+    sgr_modbus_suffix = '-SNAPSHOT'
+}
+
+
 dependencies {
-    implementation group: 'com.smartgridready', name: 'sgr-specification', version: '2.0_2024-10-08'
+    implementation group: 'com.smartgridready', name: 'sgr-specification', version: "2.0_2024-10-08${sgr_spec_suffix}"
     implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '4.0.2'
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
 
-    implementation group: 'com.smartgridready', name: 'sgr-driver-api', version: '2.0.0'
-    implementation group: 'com.smartgridready', name: 'easymodbus', version: '2.0.0'
+    implementation group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.0.0${sgr_driver_suffix}"
+    implementation group: 'com.smartgridready', name: 'easymodbus', version: "2.0.0${sgr_modbus_suffix}"
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.1.3'
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5-fluent', version: '5.1.3'
     implementation group: 'com.hivemq', name: 'hivemq-mqtt-client', version: '1.3.3'

--- a/CommHandler/build.gradle
+++ b/CommHandler/build.gradle
@@ -17,9 +17,15 @@ repositories {
 
     maven {
         url "https://nexus.library.smartgridready.ch/repository/maven-releases/"
+        mavenContent {
+            releasesOnly()
+        }
     }
     maven {
         url "https://nexus.library.smartgridready.ch/repository/maven-snapshots/"
+        mavenContent {
+            snapshotsOnly()
+        }
     }
 }
 
@@ -51,20 +57,27 @@ test {
     useJUnitPlatform() // needed to run JUnit 5 test with gradle
 }
 
-// allow snapshot dependencies when explicitly requested, use release versions by default
+// use release versions by default (no suffix)
 // spec. release date
 def sgr_spec_suffix = '_2024-10-08'
 def sgr_driver_suffix = ''
-def sgr_modbus_suffix = ''
+def easymodbus_suffix = ''
 
-if (project.hasProperty("sgr-spec-dev")) {
-    sgr_spec_suffix = '-SNAPSHOT'
-}
-if (project.hasProperty("sgr-driver-dev")) {
-    sgr_driver_suffix = '-SNAPSHOT'
-}
-if (project.hasProperty("sgr-modbus-dev")) {
-    sgr_modbus_suffix = '-SNAPSHOT'
+// use snapshots by setting property on commandline, e.g. -Psnapshots=sgr-specification,sgr-driver-api
+if (project.hasProperty("snapshots")) {
+    def snapList = project.getProperty("snapshots").split(',')
+    if (snapList.contains("sgr-specification")) {
+        println "using snapshots of sgr-specification"
+        sgr_spec_suffix = '-SNAPSHOT'
+    }
+    if (snapList.contains("sgr-driver-api")) {
+        println "using snapshots of sgr-driver-api"
+        sgr_driver_suffix = '-SNAPSHOT'
+    }
+    if (snapList.contains("easymodbus")) {
+        println "using snapshots of easymodbus"
+        easymodbus_suffix = '-SNAPSHOT'
+    }
 }
 
 
@@ -73,7 +86,7 @@ dependencies {
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
 
     api group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.0.0${sgr_driver_suffix}"
-    implementation group: 'com.smartgridready', name: 'easymodbus', version: "2.0.0${sgr_modbus_suffix}"
+    implementation group: 'com.smartgridready', name: 'easymodbus', version: "2.0.0${easymodbus_suffix}"
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.1.3'
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5-fluent', version: '5.1.3'
     implementation group: 'com.hivemq', name: 'hivemq-mqtt-client', version: '1.3.3'

--- a/Specification/build.gradle
+++ b/Specification/build.gradle
@@ -20,7 +20,7 @@ repositories {
 def xsdPath = "../../SGrSpecifications/SchemaDatabase/SGr"
 def os = System.getProperty('os.name').toLowerCase()
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 
 java {
@@ -32,13 +32,18 @@ xjc {
     xsdDir.set(layout.projectDirectory.dir(xsdPath))
     bindingFiles.setFrom(layout.projectDirectory.dir("src/main/xjb").asFileTree.matching { include("*.xjb") })
     useJakarta = true
-    addCompilationDependencies = true
+    addCompilationDependencies = false
     generateEpisode = true
 }
 
 processResources {
     from xsdPath
     exclude '.gitkeep'
+}
+
+dependencies {
+    api group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '4.0.2'
+    compileOnly group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
 }
 
 publishing {


### PR DESCRIPTION
- added gradle commandline property to use SNAPSHOT builds of SGr libraries
- improved dependency management of the published libraries: automatically include transitive dependencies, no longer requires explicit definition