### PR TITLE
Fixed RestServiceClient bug when calling a subsequent getVal()

### DIFF
--- a/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/RestServiceClient.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/RestServiceClient.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartgridready.driver.api.http.GenHttpRequestFactory;
 import com.smartgridready.driver.api.http.GenHttpResponse;
 import com.smartgridready.driver.api.http.GenHttpRequest;
@@ -37,6 +38,8 @@ import com.smartgridready.ns.v0.RestApiServiceCall;
 import com.smartgridready.ns.v0.HeaderEntry;
 
 public class RestServiceClient {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper();
 
 	private final String baseUri;
 
@@ -52,11 +55,11 @@ public class RestServiceClient {
 		HTTP_METHOD_MAP.put(HttpMethod.DELETE, com.smartgridready.driver.api.http.HttpMethod.DELETE);
 	}
 
-	protected RestServiceClient(String baseUri, RestApiServiceCall serviceCall, GenHttpRequestFactory httpRequestFactory) {
+	protected RestServiceClient(String baseUri, RestApiServiceCall serviceCall, GenHttpRequestFactory httpRequestFactory) throws IOException {
 		this(baseUri, serviceCall, httpRequestFactory, new Properties());
 	}
 
-	protected RestServiceClient(String baseUri, RestApiServiceCall serviceCall, GenHttpRequestFactory httpRequestFactory, Properties substitutions) {
+	protected RestServiceClient(String baseUri, RestApiServiceCall serviceCall, GenHttpRequestFactory httpRequestFactory, Properties substitutions) throws IOException {
 		this.baseUri = replacePropertyPlaceholders(baseUri, substitutions);
 		this.restServiceCall = cloneRestServiceCallWithSubstitutions(serviceCall, substitutions);
 		this.httpRequestFactory = httpRequestFactory;
@@ -83,34 +86,36 @@ public class RestServiceClient {
 		return restServiceCall;
 	}
 
-	private RestApiServiceCall cloneRestServiceCallWithSubstitutions(RestApiServiceCall restServiceCall, Properties substitutions) {
+	private RestApiServiceCall cloneRestServiceCallWithSubstitutions(RestApiServiceCall restServiceCall, Properties substitutions) throws IOException {
+
+		var serviceCall = cloneRestApiServiceCall(restServiceCall);
 
 		// Substitutions can appear within the request path, request body or even the response query.
-		restServiceCall.setRequestPath(replacePropertyPlaceholders(restServiceCall.getRequestPath(), substitutions));
-		restServiceCall.setRequestBody(replacePropertyPlaceholders(restServiceCall.getRequestBody(), substitutions));
+		serviceCall.setRequestPath(replacePropertyPlaceholders(serviceCall.getRequestPath(), substitutions));
+		serviceCall.setRequestBody(replacePropertyPlaceholders(serviceCall.getRequestBody(), substitutions));
 
-		if (restServiceCall.getResponseQuery() != null) {
-			restServiceCall.getResponseQuery().setQuery(replacePropertyPlaceholders(restServiceCall.getResponseQuery().getQuery(), substitutions));
+		if (serviceCall.getResponseQuery() != null) {
+			serviceCall.getResponseQuery().setQuery(replacePropertyPlaceholders(restServiceCall.getResponseQuery().getQuery(), substitutions));
 		}
 
-		ParameterList queryParams = restServiceCall.getRequestQuery();
+		ParameterList queryParams = serviceCall.getRequestQuery();
 		if (queryParams != null) {
 			queryParams.getParameter().forEach(param -> param.setValue(replacePropertyPlaceholders(param.getValue(), substitutions)));
 		}
 
-		ParameterList formParams = restServiceCall.getRequestForm();
+		ParameterList formParams = serviceCall.getRequestForm();
 		if (formParams != null) {
 			formParams.getParameter().forEach(param -> param.setValue(replacePropertyPlaceholders(param.getValue(), substitutions)));
 		}
 
-		HeaderList headers = restServiceCall.getRequestHeader();
+		HeaderList headers = serviceCall.getRequestHeader();
 		if (headers != null) {
 			headers.getHeader().forEach(header -> header.setValue(replacePropertyPlaceholders(header.getValue(), substitutions)));
 		} else {
-			restServiceCall.setRequestHeader(new HeaderList());
+			serviceCall.setRequestHeader(new HeaderList());
 		}
 
-		return restServiceCall;
+		return serviceCall;
 	}
 
 	public GenHttpResponse callService() throws IOException {
@@ -185,16 +190,21 @@ public class RestServiceClient {
 		return convertedTemplate;
 	}
 
-	public static RestServiceClient of(String baseUri, RestApiServiceCall serviceCall, GenHttpRequestFactory httpRequestFactory) {
+	public static RestServiceClient of(String baseUri, RestApiServiceCall serviceCall, GenHttpRequestFactory httpRequestFactory) throws IOException {
 		return new RestServiceClient(baseUri, serviceCall, httpRequestFactory);
 	}
 
-	public static RestServiceClient of(String baseUri, RestApiServiceCall serviceCall, GenHttpRequestFactory httpRequestFactory, Properties substitutions) {
+	public static RestServiceClient of(String baseUri, RestApiServiceCall serviceCall, GenHttpRequestFactory httpRequestFactory, Properties substitutions) throws IOException {
 		return new RestServiceClient(baseUri, serviceCall, httpRequestFactory, substitutions);
 	}
 
 	private static com.smartgridready.driver.api.http.HttpMethod mapHttpMethod(HttpMethod httpMethod) throws IOException {
 		return Optional.ofNullable(HTTP_METHOD_MAP.get(httpMethod))
 				.orElseThrow(() -> new IOException("Unsupported HTTP method: " + httpMethod.name()));
+	}
+
+	private static RestApiServiceCall cloneRestApiServiceCall(RestApiServiceCall restApiServiceCall) throws IOException {
+		var clone = objectMapper.writeValueAsString(restApiServiceCall);
+		return objectMapper.readValue(clone, RestApiServiceCall.class);
 	}
 }

--- a/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/RestServiceClientUtils.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/RestServiceClientUtils.java
@@ -19,6 +19,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.smartgridready.communicator.rest.http.client;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.smartgridready.ns.v0.HeaderEntry;
 import com.smartgridready.ns.v0.RestApiServiceCall;
@@ -33,8 +34,9 @@ public class RestServiceClientUtils {
 
 		if (restServiceCall != null) {
 			sb.append(String.format("%nRequest method: %s%n", restServiceCall.getRequestMethod() != null ? restServiceCall.getRequestMethod().name() : "n.a"));
-			sb.append(String.format("Request path:   %s%n", restServiceCall.getRequestPath()));
 			sb.append(String.format("Headers: %s%n", restServiceCall.getRequestHeader() != null ? printHeaders( restServiceCall.getRequestHeader().getHeader()) : "n.a"));
+			sb.append(String.format("Request path:   %s%n", restServiceCall.getRequestPath()));
+			sb.append(String.format("Request parameters %s%n", printUrlParameters(restServiceCall)));
 			sb.append(String.format("Request body:   %s%n", restServiceCall.getRequestBody()));
 		}
 		return sb.toString();		
@@ -44,5 +46,15 @@ public class RestServiceClientUtils {
 		StringBuilder sb = new StringBuilder();
 		headers.forEach( headerEntry -> sb.append(String.format("\t%s : %s%n", headerEntry.getHeaderName(), headerEntry.getValue())));
 		return sb.toString();
+	}
+
+	private static String printUrlParameters(RestApiServiceCall restApiServiceCall)
+	{
+		if (restApiServiceCall.getRequestQuery() != null && restApiServiceCall.getRequestQuery().getParameter() != null) {
+			return restApiServiceCall.getRequestQuery().getParameter().stream()
+					.map(param -> param.getName() + "=" + param.getValue())
+					.collect(Collectors.toList()).toString();
+		}
+		return "";
 	}
 }


### PR DESCRIPTION
When calling subsequent getVal(fp, dp, parameters) with parameters, the parameters of the first call are allways used.

The reason for that was that the {{<param_nam>}} have been replaced with first call and a subsequent call did not find any tag to replace. This will be fixed with this PR.