### PR TITLE
Modbus driver API improvement

### DIFF
--- a/CommHandler/build.gradle
+++ b/CommHandler/build.gradle
@@ -61,7 +61,7 @@ test {
 // spec. release date
 def sgr_spec_suffix = '_2024-12-19'
 def sgr_driver_suffix = '-SNAPSHOT'
-def easymodbus_suffix = '-SNAPSHOT'
+def modbus_suffix = ''
 def apachehttp_suffix = ''
 def hivemq_suffix = ''
 
@@ -76,9 +76,9 @@ if (project.hasProperty("snapshots")) {
         println "using snapshots of sgr-driver-api"
         sgr_driver_suffix = '-SNAPSHOT'
     }
-    if (snapList.contains("easymodbus")) {
-        println "using snapshots of easymodbus"
-        easymodbus_suffix = '-SNAPSHOT'
+    if (snapList.contains("sgr-driver-modbus")) {
+        println "using snapshots of modbus"
+        modbus_suffix = '-SNAPSHOT'
     }
     if (snapList.contains("sgr-driver-apachehttp")) {
         println "using snapshots of sgr-driver-apachehttp"
@@ -96,7 +96,7 @@ dependencies {
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
 
     api group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.2.0${sgr_driver_suffix}"
-    testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-j2mod', version: "0.1.0${easymodbus_suffix}"
+    testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-j2mod', version: "1.0.0${modbus_suffix}"
     testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-apachehttp', version: "2.0.0${apachehttp_suffix}"
     testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-hivemq', version: "2.0.0${hivemq_suffix}"
 

--- a/CommHandler/build.gradle
+++ b/CommHandler/build.gradle
@@ -60,8 +60,8 @@ test {
 // use release versions by default (no suffix)
 // spec. release date
 def sgr_spec_suffix = '_2024-12-19'
-def sgr_driver_suffix = ''
-def easymodbus_suffix = ''
+def sgr_driver_suffix = '-SNAPSHOT'
+def easymodbus_suffix = '-SNAPSHOT'
 def apachehttp_suffix = ''
 def hivemq_suffix = ''
 
@@ -95,8 +95,8 @@ dependencies {
     api group: 'com.smartgridready', name: 'sgr-specification', version: "2.0${sgr_spec_suffix}"
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
 
-    api group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.1.0${sgr_driver_suffix}"
-    testRuntimeOnly group: 'com.smartgridready', name: 'easymodbus', version: "2.1.0${easymodbus_suffix}"
+    api group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.2.0${sgr_driver_suffix}"
+    testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-j2mod', version: "0.1.0${easymodbus_suffix}"
     testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-apachehttp', version: "2.0.0${apachehttp_suffix}"
     testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-hivemq', version: "2.0.0${hivemq_suffix}"
 

--- a/CommHandler/gradle.properties
+++ b/CommHandler/gradle.properties
@@ -9,4 +9,4 @@
 # 7. regular checkout of release branch to continue development. increment version as soon as required.
 
 # package version to publish
-version=2.1.2-SNAPSHOT
+version=2.2.0-SNAPSHOT

--- a/CommHandler/src/main/java/com/smartgridready/communicator/modbus/helper/ModbusReader.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/modbus/helper/ModbusReader.java
@@ -41,29 +41,14 @@ public class ModbusReader {
         if (isFirstRegAddrOne) {
             regAddr = regAddr - 1;
         }
-        // shared Modbus driver instances require exclusive access
         if (RegisterType.HOLD_REGISTER == regType) {
-            // TODO synchronize on method parameter is dangerous and may result in unpredictable behaviour
-            // consider using a specific synch object.
-            synchronized(drv4Modbus) {
-                drv4Modbus.setUnitIdentifier(unitIdentifier);
-                response.setMbregresp(drv4Modbus.ReadHoldingRegisters(regAddr, length));
-            }
+            response.setMbregresp(drv4Modbus.readHoldingRegisters(unitIdentifier, regAddr, length));
         } else if (RegisterType.INPUT_REGISTER == regType) {
-            synchronized(drv4Modbus) {
-                drv4Modbus.setUnitIdentifier(unitIdentifier);
-                response.setMbregresp(drv4Modbus.ReadInputRegisters(regAddr, length));
-            }
+            response.setMbregresp(drv4Modbus.readInputRegisters(unitIdentifier, regAddr, length));
         } else if (RegisterType.DISCRETE_INPUT == regType) {
-            synchronized(drv4Modbus) {
-                drv4Modbus.setUnitIdentifier(unitIdentifier);
-                response.setMbbitresp(drv4Modbus.ReadDiscreteInputs(regAddr, length));
-            }
+            response.setMbbitresp(drv4Modbus.readDiscreteInputs(unitIdentifier, regAddr, length));
         } else if (RegisterType.COIL == regType) {
-            synchronized(drv4Modbus) {
-                drv4Modbus.setUnitIdentifier(unitIdentifier);
-                response.setMbbitresp(drv4Modbus.ReadCoils(regAddr, length));
-            }
+            response.setMbbitresp(drv4Modbus.readCoils(unitIdentifier, regAddr, length));
         } else {
             throw new GenDriverException("ModbusReader, unhandled register type requested.");
         }

--- a/CommHandler/src/main/java/com/smartgridready/communicator/modbus/helper/ModbusTransportUtil.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/modbus/helper/ModbusTransportUtil.java
@@ -21,7 +21,10 @@ public class ModbusTransportUtil {
         ModbusType modbusType = ModbusUtil.getModbusType(interfaceDescription);
         switch (modbusType) {
             case RTU:
-                return createRtuTransport(interfaceDescription.getModbusRtu(), factory);
+                return createRtuTransport(interfaceDescription.getModbusRtu(), false, factory);
+			
+			case RTU_ASCII:
+                return createRtuTransport(interfaceDescription.getModbusRtu(), true, factory);
  
             case TCP:
                 return createTcpTransport(interfaceDescription.getModbusTcp(), factory);
@@ -34,7 +37,7 @@ public class ModbusTransportUtil {
         }
 	}
 
-	private static GenDriverAPI4Modbus createRtuTransport(ModbusRtu rtu, GenDriverAPI4ModbusFactory factory) throws GenDriverException {
+	private static GenDriverAPI4Modbus createRtuTransport(ModbusRtu rtu, boolean asciiEncoding, GenDriverAPI4ModbusFactory factory) throws GenDriverException {
 		if (rtu == null) {
 			throw new GenDriverException("No Modbus RTU configuration found");
 		}
@@ -45,7 +48,7 @@ public class ModbusTransportUtil {
 		DataBits dataBits = ModbusUtil.getSerialDataBits(rtu.getByteLenSelected());
 		StopBits stopBits = ModbusUtil.getSerialStopBits(rtu.getStopBitLenSelected());
 
-		return factory.createRtuTransport(serialPort, baudrate, parity, dataBits, stopBits);
+		return factory.createRtuTransport(serialPort, baudrate, parity, dataBits, stopBits, asciiEncoding);
 	}
 
 	private static GenDriverAPI4Modbus createTcpTransport(ModbusTcp tcp, GenDriverAPI4ModbusFactory factory) throws GenDriverException {

--- a/CommHandler/src/main/java/com/smartgridready/communicator/modbus/helper/ModbusType.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/modbus/helper/ModbusType.java
@@ -4,5 +4,6 @@ public enum ModbusType {
     UNKNOWN,
     RTU,
     TCP,
-    UDP
+    UDP,
+    RTU_ASCII
 }

--- a/CommHandler/src/main/java/com/smartgridready/communicator/modbus/helper/ModbusUtil.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/modbus/helper/ModbusUtil.java
@@ -170,6 +170,9 @@ public class ModbusUtil {
 
             case RTU:
                 return ModbusType.RTU;
+            
+            case RTU_ASCII:
+                return ModbusType.RTU_ASCII;
 
             case UDPIP:
                 return ModbusType.UDP;

--- a/CommHandler/src/main/java/com/smartgridready/communicator/modbus/impl/SGrModbusDevice.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/modbus/impl/SGrModbusDevice.java
@@ -116,7 +116,8 @@ public class SGrModbusDevice extends SGrDeviceBase<DeviceFrame, ModbusFunctional
 
 		if (
 			(aGatewayRegistry != null) &&
-			(ModbusUtil.getModbusType(getModbusInterfaceDescription()) == ModbusType.RTU)
+			(ModbusUtil.getModbusType(getModbusInterfaceDescription()) == ModbusType.RTU ||
+				ModbusUtil.getModbusType(getModbusInterfaceDescription()) == ModbusType.RTU_ASCII)
 		) {
 			// only use shared registry with RTU transports
 			drvRegistry = aGatewayRegistry;

--- a/CommHandler/src/main/java/com/smartgridready/communicator/modbus/impl/SGrModbusDevice.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/modbus/impl/SGrModbusDevice.java
@@ -571,31 +571,18 @@ public class SGrModbusDevice extends SGrDeviceBase<DeviceFrame, ModbusFunctional
 	}
 
 	private void writeToModbus(short unitIdentifier, int[] mbregsnd, boolean[] mbbitsnd, boolean bRegisterCMDs, boolean bDiscreteCMDs, BigInteger regad, int mbsize) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
-		// shared Modbus driver instances require exclusive access
 		GenDriverAPI4Modbus drv4Modbus = drv4ModbusGateway.getTransport();
 		if (bRegisterCMDs) {
 			if (mbsize > 1) {
-				synchronized (drv4Modbus) {
-					drv4Modbus.setUnitIdentifier(unitIdentifier);
-					drv4Modbus.WriteMultipleRegisters(regad.intValue(), mbregsnd);
-				}
+				drv4Modbus.writeMultipleRegisters(unitIdentifier, regad.intValue(), mbregsnd);
 			} else {
-				synchronized (drv4Modbus) {
-					drv4Modbus.setUnitIdentifier(unitIdentifier);
-					drv4Modbus.WriteSingleRegister(regad.intValue(), mbregsnd[0]);
-				}
+				drv4Modbus.writeSingleRegister(unitIdentifier, regad.intValue(), mbregsnd[0]);
 			}
 		} else if (bDiscreteCMDs) {
 			if (mbsize > 1) {
-				synchronized (drv4Modbus) {
-					drv4Modbus.setUnitIdentifier(unitIdentifier);
-					drv4Modbus.WriteMultipleCoils(regad.intValue(), mbbitsnd);
-				}
+				drv4Modbus.writeMultipleCoils(unitIdentifier, regad.intValue(), mbbitsnd);
 			} else {
-				synchronized (drv4Modbus) {
-					drv4Modbus.setUnitIdentifier(unitIdentifier);
-					drv4Modbus.WriteSingleCoil(regad.intValue(), mbbitsnd[0]);
-				}
+				drv4Modbus.writeSingleCoil(unitIdentifier, regad.intValue(), mbbitsnd[0]);
 			}
 		}
 	}

--- a/CommHandler/src/test/java/com/smartgridready/communicator/async/AsyncClemapWagoTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/async/AsyncClemapWagoTest.java
@@ -150,7 +150,6 @@ public class AsyncClemapWagoTest {
         GenDriverAPI4ModbusFactory factory = DriverFactoryLoader.getModbusDriver();
         wagoDriver = factory.createRtuTransport("COM3", 19200);
         wagoDriver.connect();
-        wagoDriver.setUnitIdentifier((byte)1);
         return new SGrModbusDevice(deviceDesc, wagoDriver);
     }
 

--- a/CommHandler/src/test/java/com/smartgridready/communicator/common/api/SGrDeviceBuilderTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/common/api/SGrDeviceBuilderTest.java
@@ -172,7 +172,7 @@ public class SGrDeviceBuilderTest {
         Properties properties = new Properties();
         properties.put("portName", "COM3");
 
-        when(modbusClientFactory.createRtuTransport(anyString(), anyInt(), any(), any(), any())).thenReturn(modbusDriver);
+        when(modbusClientFactory.createRtuTransport(anyString(), anyInt(), any(), any(), any(), anyBoolean())).thenReturn(modbusDriver);
 
         GenDeviceApi device = new SGrDeviceBuilder()
                 .useModbusClientFactory(modbusClientFactory)

--- a/CommHandler/src/test/java/com/smartgridready/communicator/common/impl/SGrDeviceBaseTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/common/impl/SGrDeviceBaseTest.java
@@ -58,6 +58,7 @@ import static com.smartgridready.communicator.common.api.values.DataType.UNKNOWN
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -244,7 +245,7 @@ class SGrDeviceBaseTest {
         var modbusValue = Float32Value.of(voltage).toModbusRegister(modbusDataType);
 
         when(modbusClientFactory.createRtuTransport(anyString(), anyInt(), any(), any(), any())).thenReturn(genDriverAPI4Modbus);
-        when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt()))
+        when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt()))
                 .thenReturn(modbusValue);
 
         var device = createSGrModbusDevice("SGr_04_0014_0000_WAGO_SmartMeterV0.2.1-GenericAttributes.xml");
@@ -261,7 +262,7 @@ class SGrDeviceBaseTest {
         value = Float32Value.of(unitConversionFactor * voltage);
         dataPoint.setVal(value);
 
-        verify(genDriverAPI4Modbus).WriteMultipleRegisters(intCaptor1.capture(), intCaptor2.capture());
+        verify(genDriverAPI4Modbus).writeMultipleRegisters(anyShort(), intCaptor1.capture(), intCaptor2.capture());
         assertEquals(20482, intCaptor1.getValue());   // Address
         assertArrayEquals(modbusValue, intCaptor2.getValue()); // float value on modbus
     }
@@ -348,7 +349,7 @@ class SGrDeviceBaseTest {
         System.arraycopy(modbusValue, 0, modbusValues, 2*modbusValue.length,modbusValue.length);
 
         when(modbusClientFactory.createRtuTransport(anyString(), anyInt(), any(), any(), any())).thenReturn(genDriverAPI4Modbus);
-        when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt()))
+        when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt()))
                 .thenReturn(modbusValues);
 
         var device = createSGrModbusDevice("SGr_04_0014_0000_WAGO_SmartMeterV0.2.1-Arrays.xml");
@@ -366,7 +367,7 @@ class SGrDeviceBaseTest {
         // Check write value
         dataPoint.setVal(ArrayValue.of(values));
 
-        verify(genDriverAPI4Modbus).WriteMultipleRegisters(intCaptor1.capture(), intCaptor2.capture());
+        verify(genDriverAPI4Modbus).writeMultipleRegisters(anyShort(), intCaptor1.capture(), intCaptor2.capture());
         assertEquals(20482, intCaptor1.getValue());   // Address
         assertArrayEquals(modbusValues, intCaptor2.getValue()); // float value on modbus
     }

--- a/CommHandler/src/test/java/com/smartgridready/communicator/common/impl/SGrDeviceBaseTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/common/impl/SGrDeviceBaseTest.java
@@ -57,6 +57,7 @@ import static com.smartgridready.communicator.common.api.values.DataType.ENUM;
 import static com.smartgridready.communicator.common.api.values.DataType.UNKNOWN;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -244,7 +245,7 @@ class SGrDeviceBaseTest {
 
         var modbusValue = Float32Value.of(voltage).toModbusRegister(modbusDataType);
 
-        when(modbusClientFactory.createRtuTransport(anyString(), anyInt(), any(), any(), any())).thenReturn(genDriverAPI4Modbus);
+        when(modbusClientFactory.createRtuTransport(anyString(), anyInt(), any(), any(), any(), anyBoolean())).thenReturn(genDriverAPI4Modbus);
         when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt()))
                 .thenReturn(modbusValue);
 
@@ -348,7 +349,7 @@ class SGrDeviceBaseTest {
         System.arraycopy(modbusValue, 0, modbusValues, modbusValue.length, modbusValue.length);
         System.arraycopy(modbusValue, 0, modbusValues, 2*modbusValue.length,modbusValue.length);
 
-        when(modbusClientFactory.createRtuTransport(anyString(), anyInt(), any(), any(), any())).thenReturn(genDriverAPI4Modbus);
+        when(modbusClientFactory.createRtuTransport(anyString(), anyInt(), any(), any(), any(), anyBoolean())).thenReturn(genDriverAPI4Modbus);
         when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt()))
                 .thenReturn(modbusValues);
 

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GenDriverAPI4ModbusRTUMock.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GenDriverAPI4ModbusRTUMock.java
@@ -36,6 +36,9 @@ public class GenDriverAPI4ModbusRTUMock implements GenDriverAPI4Modbus {
 	public void setIsIntegerType(boolean returnInteger) {
 		this.returnInteger = returnInteger;
 	}
+
+	@Override
+	public void setUnitIdentifier(short unitId) {}
 	
 	@Override
 	public int[] ReadInputRegisters(int startingAddress, int quantity) {

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GetValArrayTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GetValArrayTester.java
@@ -37,9 +37,6 @@ public class GetValArrayTester {
 			GenDeviceApi4Modbus devWagoMeter = new SGrModbusDevice(tstMeter, mbRTU );
 			
 			try {	
-				// set device address of devWagoMeter
-					
-				mbRTU.setUnitIdentifier((byte) 1);
 				Value[] voltages = devWagoMeter.getVal("VoltageAC", "Voltage-L1-L2-L3").asArray();
 				
 				// Voltages as GDP type

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GetValArrayTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GetValArrayTester.java
@@ -6,13 +6,13 @@ import com.smartgridready.communicator.common.api.values.Value;
 import com.smartgridready.communicator.common.helper.DeviceDescriptionLoader;
 import com.smartgridready.communicator.common.helper.DriverFactoryLoader;
 import com.smartgridready.communicator.modbus.api.GenDeviceApi4Modbus;
-import com.smartgridready.driver.api.modbus.GenDriverAPI4Modbus;
 import com.smartgridready.driver.api.modbus.GenDriverAPI4ModbusFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
+import java.util.Properties;
 
 public class GetValArrayTester {
 		
@@ -26,15 +26,17 @@ public class GetValArrayTester {
 		ClassLoader classloader = Thread.currentThread().getContextClassLoader();
 		URL deviceDesc = classloader.getResource("SGr_04_0014_0000_WAGO_SmartMeterV0.2.1-Arrays.xml");
 		
-		try {	
+		try {
+			Properties props = new Properties();
+			props.setProperty("portName", "COM3");
+
 			DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
-			DeviceFrame tstMeter = loader.load( XML_BASE_DIR, deviceDesc != null ?deviceDesc.getPath() : null);
+			DeviceFrame tstMeter = loader.load(XML_BASE_DIR, deviceDesc != null ? deviceDesc.getPath() : null, props);
 			
 			GenDriverAPI4ModbusFactory factory = DriverFactoryLoader.getModbusDriver();
-			GenDriverAPI4Modbus mbRTU = factory.createRtuTransport("COM3", 19200);
-			mbRTU.connect();	
 			
-			GenDeviceApi4Modbus devWagoMeter = new SGrModbusDevice(tstMeter, mbRTU );
+			GenDeviceApi4Modbus devWagoMeter = new SGrModbusDevice(tstMeter, factory);
+			devWagoMeter.connect();
 			
 			try {	
 				Value[] voltages = devWagoMeter.getVal("VoltageAC", "Voltage-L1-L2-L3").asArray();
@@ -64,13 +66,14 @@ public class GetValArrayTester {
 				voltages = devWagoMeter.getVal("VoltageAC", "Voltage-L1-L2-L3").asArray();
 				LOG.info("WAGO Meter Voltages AC run 4; L1: {}V - L2 {}V - L3: {}V",
 						voltages[0], voltages[1], voltages[2]);
-				
 			}
 			catch ( Exception e)
 			{
 				System.out.println( "Error reading value from device. " + e);
 				e.printStackTrace();
 			}
+
+			devWagoMeter.disconnect();
 		}		
 		catch ( Exception e )
 		{

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GetValBlockTransferTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GetValBlockTransferTester.java
@@ -38,11 +38,6 @@ public class GetValBlockTransferTester {
 			GenDeviceApi4Modbus devWagoMeter = new SGrModbusDevice(tstMeter, mbRTU );
 			
 			try {	
-				// set device address of devWagoMeter
-					
-				mbRTU.setUnitIdentifier((byte) 1);				
-				
-				
 				// Voltages from device
 				Value voltage1 = devWagoMeter.getVal("VoltageAC", "VoltageACL1-L2");
 				Value voltage2 = devWagoMeter.getVal("VoltageAC", "VoltageACL1-L3");

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GetValBlockTransferTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/GetValBlockTransferTester.java
@@ -1,12 +1,12 @@
 package com.smartgridready.communicator.modbus.impl;
 
 import java.net.URL;
+import java.util.Properties;
 
 import com.smartgridready.ns.v0.DeviceFrame;
 
 import com.smartgridready.communicator.common.api.values.Value;
 import com.smartgridready.communicator.modbus.api.GenDeviceApi4Modbus;
-import com.smartgridready.driver.api.modbus.GenDriverAPI4Modbus;
 import com.smartgridready.driver.api.modbus.GenDriverAPI4ModbusFactory;
 
 import org.slf4j.Logger;
@@ -27,15 +27,17 @@ public class GetValBlockTransferTester {
 		ClassLoader classloader = Thread.currentThread().getContextClassLoader();
 		URL deviceDesc = classloader.getResource("SGr_04_0014_0000_WAGO_SmartMeterV0.2.1-Blocktransfer.xml");
 		
-	try {
+		try {
+			Properties props = new Properties();
+			props.setProperty("portName", "COM3");
+
 			DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
-			DeviceFrame tstMeter = loader.load( XML_BASE_DIR, deviceDesc != null ? deviceDesc.getPath() : null);
+			DeviceFrame tstMeter = loader.load(XML_BASE_DIR, deviceDesc != null ? deviceDesc.getPath() : null, props);
 			
 			GenDriverAPI4ModbusFactory factory = DriverFactoryLoader.getModbusDriver();
-			GenDriverAPI4Modbus mbRTU = factory.createRtuTransport("COM3", 19200);
-			mbRTU.connect();
 
-			GenDeviceApi4Modbus devWagoMeter = new SGrModbusDevice(tstMeter, mbRTU );
+			GenDeviceApi4Modbus devWagoMeter = new SGrModbusDevice(tstMeter, factory);
+			devWagoMeter.connect();
 			
 			try {	
 				// Voltages from device
@@ -70,6 +72,8 @@ public class GetValBlockTransferTester {
 				System.out.println( "Error reading value from device. " + e);
 				e.printStackTrace();
 			}
+
+			devWagoMeter.disconnect();
 		}
 		catch ( Exception e )
 		{

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/HeatPumpTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/HeatPumpTester.java
@@ -650,9 +650,6 @@ public class HeatPumpTester {
 				DataTypeProduct  modeCmd = new DataTypeProduct();
 				
 					try {	
-						// if RTU is used, set address here
-						// mbRTU.setUnitIdentifier((byte) 7);
-					     
 						LOG.info(String.format("Testing CTAoptiHeat"));
 						Thread.sleep(25);
 						

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/HeatPumpTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/HeatPumpTester.java
@@ -26,6 +26,7 @@ package com.smartgridready.communicator.modbus.impl;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Properties;
 
 import com.smartgridready.ns.v0.DataTypeProduct;
 import com.smartgridready.ns.v0.DeviceFrame;
@@ -111,9 +112,16 @@ public class HeatPumpTester {
 			  mbRTU.connect();			
 			}
 			
-			if (devStiebelISGIsOn) initStiebelISG(XML_BASE_DIR, "SGr_04_0015_xxxx_StiebelEltron_HeatPumpV0.2.1.xml");			
-			if (devCTAoptiHeatIsOn) initCTAoptiHeat(XML_BASE_DIR, "SGr_04_0033_0000_CTA_HeatPumpV0.2.1.xml");
-			if (devHovalTCPIsOn) initHovalTCP (XML_BASE_DIR, "SGr_04_0017_xxxx_HOVAL_HeatPumpV0.2.1.xml");
+			// TODO device parameters, e.g. slave ID, must be set HERE!
+			if (devStiebelISGIsOn) {
+				initStiebelISG(XML_BASE_DIR, "SGr_04_0015_xxxx_StiebelEltron_HeatPumpV0.2.1.xml");
+			}
+			if (devCTAoptiHeatIsOn) {
+				initCTAoptiHeat(XML_BASE_DIR, "SGr_04_0033_0000_CTA_HeatPumpV0.2.1.xml");
+			}
+			if (devHovalTCPIsOn) {
+				initHovalTCP(XML_BASE_DIR, "SGr_04_0017_xxxx_HOVAL_HeatPumpV0.2.1.xml");
+			}
 			
 			// **************************   Start device Testing   **********************************						
    			

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IBTlabLoopTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IBTlabLoopTester.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Properties;
 
 public class IBTlabLoopTester {
 
@@ -110,7 +111,7 @@ public class IBTlabLoopTester {
 
 			mbRTU.connect();
 			if (devABBMeterTestIsOn)  {
-				LOG.info(" -init devABBMeterTest @:" + dtf.format(LocalDateTime.now())+ " ");initABBMeter(XML_BASE_DIR, "SGr_00_0016_dddd_ABB_B23_V0.2.xml");
+				LOG.info(" -init devABBMeterTest @:" + dtf.format(LocalDateTime.now())+ " ");initABBMeter(XML_BASE_DIR, "SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml", (short) 11);
 			}
 			if (devVGT_SGCPTestIsOn)   {
 				LOG.info(" -init devVGT_SGCPTest @:" + dtf.format(LocalDateTime.now())+ " ");initVGT_SGCP (XML_BASE_DIR,"SGr_04_0019_0059_VGT_SPSDeviceforHomeAutomation_v0.2.1.xml");
@@ -124,11 +125,11 @@ public class IBTlabLoopTester {
 
 			// TestBox
 			if (devTB_ABBMeterTestIsOn)  {
-				LOG.info(" -init TestBox: devTB_ABBMeterTest @:" + dtf.format(LocalDateTime.now())+ " ");initTB_ABBMeter(XML_BASE_DIR, "SGr_00_0016_dddd_ABB_B23_V0.2.xml");
+				LOG.info(" -init TestBox: devTB_ABBMeterTest @:" + dtf.format(LocalDateTime.now())+ " ");initTB_ABBMeter(XML_BASE_DIR, "SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml", (short) 1);
 			}
 			if (devWagoMeterTestIsOn) {
 				LOG.info(" -init TestBox: devWagoMeterTest @: " + dtf.format(LocalDateTime.now())+ " ");
-				initWagoMeter(XML_BASE_DIR, "SGr_04_0014_0000_WAGO_SmartMeterV0.2.1.xml");
+				initWagoMeter(XML_BASE_DIR, "SGr_04_0014_0000_WAGO_SmartMeterV0.2.3.xml", (short) 7);
 			}
 			if (devOMCCIWallboxTestIsOn) {
 				//TODO: complete and use OMCCI EI.xml
@@ -186,18 +187,17 @@ public class IBTlabLoopTester {
 	// -----------------------------------------------------------------------------------------------------------------------------
 	// WAGO Meter testing
 	// -----------------------------------------------------------------------------------------------------------------------------
-	static void initWagoMeter(String aBaseDir, String aDescriptionFile ) {
+	static void initWagoMeter(String aBaseDir, String aDescriptionFile, short slaveId) {
 
 		try {
+			Properties props = new Properties();
+			props.setProperty("slave_id", String.valueOf(slaveId));
+
 			DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
-			DeviceFrame tstMeter = loader.load(aBaseDir,aDescriptionFile);
+			DeviceFrame tstMeter = loader.load(aBaseDir, aDescriptionFile, props);
 
-
-			devWagoMeter =  new SGrModbusDevice(tstMeter, mbRTU );
-
-
+			devWagoMeter =  new SGrModbusDevice(tstMeter, mbRTU);
 		}
-
 		catch ( Exception e )
 		{
 			LOG.info( "Error loading device description devWagoMeter:" + e);
@@ -337,15 +337,16 @@ public class IBTlabLoopTester {
 	// -----------------------------------------------------------------------------------------------------------------------------
 	// Device ABBMeter Testing
 	// -----------------------------------------------------------------------------------------------------------------------------
-	static void initABBMeter(String aBaseDir, String aDescriptionFile ) {
+	static void initABBMeter(String aBaseDir, String aDescriptionFile, short slaveId) {
 
 		try {
+			Properties props = new Properties();
+			props.setProperty("slave_id", String.valueOf(slaveId));
+
 			DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
-			DeviceFrame tstDesc = loader.load(aBaseDir, aDescriptionFile);
-			devABBMeter =  new SGrModbusDevice(tstDesc, mbRTU );
-
+			DeviceFrame tstDesc = loader.load(aBaseDir, aDescriptionFile, props);
+			devABBMeter =  new SGrModbusDevice(tstDesc, mbRTU);
 		}
-
 		catch ( Exception e )
 		{
 			LOG.info( "Error loading device description. " + e);
@@ -478,13 +479,15 @@ public class IBTlabLoopTester {
 	// -----------------------------------------------------------------------------------------------------------------------------
 	// Device ABBMeter Testing
 	// -----------------------------------------------------------------------------------------------------------------------------
-	static void initTB_ABBMeter(String aBaseDir, String aDescriptionFile ) {
+	static void initTB_ABBMeter(String aBaseDir, String aDescriptionFile, short slaveId) {
 
 		try {
+			Properties props = new Properties();
+			props.setProperty("slave_id", String.valueOf(slaveId));
+
 			DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
 			DeviceFrame tstDesc = loader.load(aBaseDir, aDescriptionFile);
 			devTB_ABBMeter =  new SGrModbusDevice(tstDesc, mbRTU );
-
 		}
 
 		catch ( Exception e )
@@ -988,11 +991,14 @@ public class IBTlabLoopTester {
 	// -----------------------------------------------------------------------------------------------------------------------------
 	// Device testing frame
 	// -----------------------------------------------------------------------------------------------------------------------------
-	static void initEmptyDevFrame(String aBaseDir, String aDescriptionFile ) {
+	static void initEmptyDevFrame(String aBaseDir, String aDescriptionFile, short slaveId) {
 
 		try {
+			Properties props = new Properties();
+			props.setProperty("slave_id", String.valueOf(slaveId));
+
 			DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
-			DeviceFrame tstDesc = loader.load(aBaseDir, aDescriptionFile);
+			DeviceFrame tstDesc = loader.load(aBaseDir, aDescriptionFile, props);
 
 			// replace device specific for RTU
 			//add devXXXX =  new SGrModbusDevice(tstDesc, mbRTU );
@@ -1003,7 +1009,6 @@ public class IBTlabLoopTester {
 			// mbXXXXX.initDevice("192.168.1.182",502);
 
 		}
-
 		catch ( Exception e )
 		{
 			LOG.info( "Error loading device description. " + e);

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IBTlabLoopTester.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IBTlabLoopTester.java
@@ -210,7 +210,6 @@ public class IBTlabLoopTester {
 		String  sVal1 = "0.0", sVal2 = "0.0", sVal3 = "0.0", sVal4 ="0.0";
 
 		try {
-			mbRTU.setUnitIdentifier((byte) 7);
 			LOG.info("\n@:Testing TestBox: WAGO Meter");
 			Thread.sleep(25);
 			fVal1 = devWagoMeter.getVal("VoltageAC", "VoltageL1").getFloat64();
@@ -359,7 +358,6 @@ public class IBTlabLoopTester {
 		String  sVal1 = "0.0", sVal2 = "0.0", sVal3 = "0.0", sVal4 ="0.0";
 
 		try {
-			mbRTU.setUnitIdentifier((byte) 11);
 			LOG.info("\n@:Testing ABBMeter: ");
 			Thread.sleep(25);
 			fVal1 = devABBMeter.getVal("VoltageAC", "VoltageL1").getFloat64();
@@ -501,9 +499,6 @@ public class IBTlabLoopTester {
 		String  sVal1 = "0.0", sVal2 = "0.0", sVal3 = "0.0", sVal4 ="0.0";
 
 		try {
-			mbRTU.setUnitIdentifier((byte) 1 );
-
-
 			LOG.info("\n@:Testing TestBox: ABBMeter: ");
 			Thread.sleep(50);
 			fVal1 = devTB_ABBMeter.getVal("VoltageAC", "VoltageL1").getFloat64();
@@ -1021,9 +1016,6 @@ public class IBTlabLoopTester {
 		String  sVal1 = "0.0", sVal2 = "0.0", sVal3 = "0.0", sVal4 ="0.0";
 
 		try {
-			// if RTU is used, set address here
-			// mbRTU.setUnitIdentifier((byte) 7);
-
 			LOG.info("@:Testing   xxxxx");
 			Thread.sleep(25);
 

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IOPdemoBOX.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IOPdemoBOX.java
@@ -170,7 +170,6 @@ public class IOPdemoBOX {
 		String  sVal1 = "0.0", sVal2 = "0.0", sVal3 = "0.0", sVal4 ="0.0";
 
 		try {
-			mbRTU.setUnitIdentifier(rtuAddr);
 			LOG.info("@:Testing IOPMeterData: ");
 			Thread.sleep(25);
 			fVal1 = devIOPMeter.getVal("VoltageAC", "VoltageL1").getFloat64();

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IOPdemoBOX.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/IOPdemoBOX.java
@@ -26,6 +26,7 @@ package com.smartgridready.communicator.modbus.impl;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Properties;
 
 // WIP/cb import com.smartgridready.ns.v0.SGrBool2BitRankType;
 import com.smartgridready.ns.v0.DeviceFrame;
@@ -146,16 +147,15 @@ public class IOPdemoBOX {
 	// -----------------------------------------------------------------------------------------------------------------------------
 	// Device IOPMeter Testing
 	// -----------------------------------------------------------------------------------------------------------------------------
-	static byte rtuAddr=0;
-
 	static void initIOPMeter(String aBaseDir, String aDescriptionFile, byte deviceAddr ) {
 
 		try {
-			rtuAddr = deviceAddr;
-			DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
-			DeviceFrame tstDesc = loader.load(aBaseDir, aDescriptionFile);
-			devIOPMeter =  new SGrModbusDevice(tstDesc, mbRTU );
+			Properties props = new Properties();
+			props.setProperty("slave_id", String.valueOf(deviceAddr));
 
+			DeviceDescriptionLoader loader = new DeviceDescriptionLoader();
+			DeviceFrame tstDesc = loader.load(aBaseDir, aDescriptionFile, props);
+			devIOPMeter =  new SGrModbusDevice(tstDesc, mbRTU);
 		}
 
 		catch ( Exception e )

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/SetGetValConversionTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/SetGetValConversionTest.java
@@ -83,6 +83,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -494,22 +495,22 @@ class SetGetValConversionTest {
         Fixture<boolean[]> fixture = new Fixture<>(BooleanValue.of(testParam._2), BooleanValue.of(testParam._2),
                 new boolean[]{testParam._2()}, deviceFrame);
 
-        when(genDriverAPI4Modbus.ReadCoils(anyInt(), anyInt())).thenReturn(new boolean[]{testParam._2} );
+        when(genDriverAPI4Modbus.readCoils(anyShort(), anyInt(), anyInt())).thenReturn(new boolean[]{testParam._2} );
 
         SGrModbusDevice modbusDevice = new SGrModbusDevice(
                 fixture.getDeviceFrame(),           // model
                 genDriverAPI4Modbus);                     // mock
 
         modbusDevice.setVal("ActivePowerAC", "ActivePowerACL1", fixture.getWriteValue());
-        verify(genDriverAPI4Modbus).WriteSingleCoil(anyInt(), booleanCaptor.capture());
+        verify(genDriverAPI4Modbus).writeSingleCoil(anyShort(), anyInt(), booleanCaptor.capture());
 
         LOG.info("Modbus write coils: {}", booleanCaptor.getAllValues().isEmpty() ? "-" : booleanCaptor.getValue());
         assertEquals(fixture.getExpectedModbusValue()[0], booleanCaptor.getValue());
-        when(genDriverAPI4Modbus.ReadCoils(anyInt(), anyInt())).thenReturn(new boolean[]{booleanCaptor.getValue()});
+        when(genDriverAPI4Modbus.readCoils(anyShort(), anyInt(), anyInt())).thenReturn(new boolean[]{booleanCaptor.getValue()});
 
         Value res = modbusDevice.getVal("ActivePowerAC", "ActivePowerACL1");
 
-        verify(genDriverAPI4Modbus).ReadCoils(anyInt(), anyInt());
+        verify(genDriverAPI4Modbus).readCoils(anyShort(), anyInt(), anyInt());
         LOG.info("Modbus read value: {}", res.getBoolean());
         assertEquals(fixture.readValue.getBoolean(), res.getBoolean());
     }
@@ -529,12 +530,12 @@ class SetGetValConversionTest {
         SGrModbusDevice modbusDevice = new SGrModbusDevice(deviceFrame, genDriverAPI4Modbus);
 
         modbusDevice.setVal("ActivePowerAC", "ActivePowerACL1", EnumValue.of("DHW_PUSH"));
-        verify(genDriverAPI4Modbus).WriteMultipleRegisters(anyInt(), intArrayCaptor.capture());
+        verify(genDriverAPI4Modbus).writeMultipleRegisters(anyShort(), anyInt(), intArrayCaptor.capture());
 
         if (!intArrayCaptor.getAllValues().isEmpty()) {
             LOG.info("Modbus write enum: {}", intArrayCaptor.getValue());
             assertArrayEquals(new int[]{0, 255}, intArrayCaptor.getValue());
-            when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(),anyInt())).thenReturn(intArrayCaptor.getValue());
+            when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(intArrayCaptor.getValue());
         }
 
         Value res = modbusDevice.getVal("ActivePowerAC", "ActivePowerACL1");
@@ -571,11 +572,11 @@ class SetGetValConversionTest {
 
         modbusDevice.setVal("ActivePowerAC", "ActivePowerACL1", BitmapValue.of(bitsToSet));
 
-        verify(genDriverAPI4Modbus).WriteMultipleRegisters(anyInt(), intArrayCaptor.capture());
+        verify(genDriverAPI4Modbus).writeMultipleRegisters(anyShort(), anyInt(), intArrayCaptor.capture());
         LOG.info("Modbus write bitmap: {}", intArrayCaptor.getValue());
         assertArrayEquals(expectedModbusValue, intArrayCaptor.getValue());
 
-        when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(intArrayCaptor.getValue());
+        when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(intArrayCaptor.getValue());
 
         Value res = modbusDevice.getVal("ActivePowerAC", "ActivePowerACL1");
         LOG.info("Modbus read value: {}", res);
@@ -610,7 +611,7 @@ class SetGetValConversionTest {
         SGrModbusDevice modbusDevice = new SGrModbusDevice(deviceFrame, genDriverAPI4Modbus);
 
         int[] expectedModbusValue = new int[]{0x00000004, 0x0000010B};
-        when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(expectedModbusValue);
+        when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(expectedModbusValue);
 
 
         Value res = modbusDevice.getVal("ActivePowerAC", "ActivePowerACL1");
@@ -645,11 +646,11 @@ class SetGetValConversionTest {
         modbusDevice.setVal("ActivePowerAC", "ActivePowerACL1", BitmapValue.of(modifiedBitmap));
 
 
-        verify(genDriverAPI4Modbus).WriteMultipleRegisters(anyInt(), intArrayCaptor.capture());
+        verify(genDriverAPI4Modbus).writeMultipleRegisters(anyShort(), anyInt(), intArrayCaptor.capture());
         LOG.info("Modbus write bitmap: {}", intArrayCaptor.getValue());
         assertArrayEquals(expectedModbusValue, intArrayCaptor.getValue());
 
-        when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(intArrayCaptor.getValue());
+        when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(intArrayCaptor.getValue());
 
         res = modbusDevice.getVal("ActivePowerAC", "ActivePowerACL1");
         LOG.info("Modbus read value: {}", res);
@@ -681,7 +682,7 @@ class SetGetValConversionTest {
         int[] expectedModbusValues = new int[]{23363, 19180, 23619, 0, 23619, -15072};
 
 
-        when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(expectedModbusValues);
+        when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(expectedModbusValues);
 
         SGrModbusDevice modbusDevice = new SGrModbusDevice(
                 deviceFrame,                              // model
@@ -691,7 +692,7 @@ class SetGetValConversionTest {
         var values = ArrayValue.of(expectedValues);
 
         modbusDevice.setVal("ActivePowerAC", "ActivePowerAC-ARRAY", values);
-        verify(genDriverAPI4Modbus, atLeast(1)).WriteMultipleRegisters(anyInt(), intArrayCaptor.capture());
+        verify(genDriverAPI4Modbus, atLeast(1)).writeMultipleRegisters(anyShort(), anyInt(), intArrayCaptor.capture());
 
         if (!intArrayCaptor.getAllValues().isEmpty()) {
             int[] modbusreg = intArrayCaptor.getValue();
@@ -702,7 +703,7 @@ class SetGetValConversionTest {
             modbusreg = adjustSign(modbusreg);
             LOG.info("Modbus write-read-back registers: {}", intArrayToShortHex(modbusreg));
             assertArrayEquals(expectedModbusValues, modbusreg);
-            when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(modbusreg);
+            when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(modbusreg);
         }
 
         Value[] res = modbusDevice.getVal("ActivePowerAC", "ActivePowerAC-ARRAY").asArray();
@@ -728,7 +729,7 @@ class SetGetValConversionTest {
 
 
         modbusDevice.setVal("ActivePowerAC", "ActivePowerAC-BLOCK", expectedValue);
-        verify(genDriverAPI4Modbus).WriteMultipleRegisters(anyInt(), intArrayCaptor.capture());
+        verify(genDriverAPI4Modbus).writeMultipleRegisters(anyShort(), anyInt(), intArrayCaptor.capture());
         LOG.info("Modbus write multiple registers (single value): {}", intArrayCaptor.getAllValues().isEmpty() ? "-" : intArrayToShortHex(intArrayCaptor.getValue()));
 
         if (!intArrayCaptor.getAllValues().isEmpty()) {
@@ -746,7 +747,7 @@ class SetGetValConversionTest {
             assertArrayEquals(expectedModbusValues, modbusregRead);
             modbusregRead = adjustSign(modbusregRead);
             LOG.info("Modbus read multiple registers: {}", intArrayToShortHex(modbusregRead));
-            when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(modbusregRead);
+            when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(modbusregRead);
         }
 
         // Mock the read cache before doing the read test.
@@ -760,7 +761,7 @@ class SetGetValConversionTest {
 
         // Test the block read.
         Value res = modbusDevice.getVal("ActivePowerAC", "ActivePowerAC-BLOCK");
-        verify(genDriverAPI4Modbus).ReadHoldingRegisters(TIME_SYNC_BLOCK_ADDRESS, TIME_SYNC_BLOCK_SIZE);
+        verify(genDriverAPI4Modbus).readHoldingRegisters((short)1, TIME_SYNC_BLOCK_ADDRESS, TIME_SYNC_BLOCK_SIZE);
 
         assertEquals(1, cacheRecords.size(), "Cache has not been written during modbus read.");
 
@@ -788,8 +789,8 @@ class SetGetValConversionTest {
         modbusDevice.setVal("ActivePowerAC", "ActivePowerACL1", fixture.getWriteValue());
 
         // then
-        verify(genDriverAPI4Modbus, atLeast(0)).WriteMultipleRegisters(anyInt(), intArrayCaptor.capture());
-        verify(genDriverAPI4Modbus, atLeast(0)).WriteSingleRegister(anyInt(), intCaptor.capture());
+        verify(genDriverAPI4Modbus, atLeast(0)).writeMultipleRegisters(anyShort(), anyInt(), intArrayCaptor.capture());
+        verify(genDriverAPI4Modbus, atLeast(0)).writeSingleRegister(anyShort(), anyInt(), intCaptor.capture());
 
         if (!intArrayCaptor.getAllValues().isEmpty()) {
             int[] modbusRegReceived = intArrayCaptor.getValue();
@@ -798,11 +799,11 @@ class SetGetValConversionTest {
             assertEquals(fixture.getExpectedModbusValue().length, modbusRegReceived.length,
                     "Invalid length of values written to the modbus registers.");
 
-            when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(modbusRegReceived);
+            when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(modbusRegReceived);
 
         } else if (!intCaptor.getAllValues().isEmpty()){
             LOG.info("Modbus write-read-back single register: {}", Integer.toHexString(intCaptor.getValue()));
-            when(genDriverAPI4Modbus.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(new int[]{intCaptor.getValue()});
+            when(genDriverAPI4Modbus.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(new int[]{intCaptor.getValue()});
         }
 
         Value resVal = modbusDevice.getVal("ActivePowerAC", "ActivePowerACL1");

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/SetGetValValidationTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/SetGetValValidationTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,7 +71,7 @@ class SetGetValValidationTest {
             if(isWrite) {
                 assertDoesNotThrow(() -> modbusDevice.setVal("VoltageAC", dataPointName, Float32Value.of(380.0f)));
             } else {
-                when(modbusDriver.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(new int[]{0,0});
+                when(modbusDriver.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(new int[]{0,0});
                 assertDoesNotThrow(() -> modbusDevice.getVal("VoltageAC", dataPointName));
             }
         } else {

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/SetValUnitConversionTest.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/impl/SetValUnitConversionTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,10 +42,10 @@ class SetValUnitConversionTest
 
         modbusDevice.setVal("VoltageAC", "VoltageL1", Float32Value.of(expectedValue));
 
-        verify(modbusDriver).WriteMultipleRegisters(anyInt(), intArrayCaptor.capture());
+        verify(modbusDriver).writeMultipleRegisters(anyShort(), anyInt(), intArrayCaptor.capture());
         assertArrayEquals(modbusRegisters, intArrayCaptor.getValue());
 
-        when(modbusDriver.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(modbusRegisters);
+        when(modbusDriver.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(modbusRegisters);
 
         float resVal = createModbusDevice().getVal("VoltageAC", "VoltageL1").getFloat32();
         LOG.info("getSetValWithConversion: expectedVal={}, resVal={}", expectedValue, resVal);
@@ -61,10 +62,10 @@ class SetValUnitConversionTest
 
         modbusDevice.setVal("ActiveEnergyAC", "ActiveEnergyACtot", Float32Value.of(expectedValue));
 
-        verify(modbusDriver).WriteMultipleRegisters(anyInt(), intArrayCaptor.capture());
+        verify(modbusDriver).writeMultipleRegisters(anyShort(), anyInt(), intArrayCaptor.capture());
         assertArrayEquals(modbusRegisters, intArrayCaptor.getValue());
 
-        when(modbusDriver.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(modbusRegisters);
+        when(modbusDriver.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(modbusRegisters);
 
         float resVal = createModbusDevice().getVal("ActiveEnergyAC", "ActiveEnergyACtot").getFloat32();
         LOG.info("getSetValWithScaling: expectedVal={}, resVal={}", expectedValue, resVal);
@@ -79,7 +80,7 @@ class SetValUnitConversionTest
         int[] modbusRegisters = new int[]{0x00000024, 0x00000a4}; // int H2L 36kW 164W
         int expectedValue = 36164;
 
-        when(modbusDriver.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(modbusRegisters);
+        when(modbusDriver.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(modbusRegisters);
 
         Value resVal = modbusDevice.getVal("ActiveEnergyAC", "ActiveEnergyACL1");
         LOG.info("setGetValWithLayer6Deviation_H2L: expectedVal={}, resVal={}", expectedValue, resVal.getInt32());
@@ -94,7 +95,7 @@ class SetValUnitConversionTest
         int[] modbusRegisters = new int[]{0x000000a4, 0x0000024}; // int H2L 36kW 164W
         int expectedValue = 36164;
 
-        when(modbusDriver.ReadHoldingRegisters(anyInt(), anyInt())).thenReturn(modbusRegisters);
+        when(modbusDriver.readHoldingRegisters(anyShort(), anyInt(), anyInt())).thenReturn(modbusRegisters);
 
         Value resVal = modbusDevice.getVal("ActiveEnergyAC", "ActiveEnergyACL2");
         LOG.info("setGetValWithLayer6Deviation_L2H: expectedVal={}, resVal={}", expectedValue, resVal.getInt32());

--- a/CommHandler/src/test/java/com/smartgridready/communicator/modbus/integrationtest/TestDevice.java
+++ b/CommHandler/src/test/java/com/smartgridready/communicator/modbus/integrationtest/TestDevice.java
@@ -94,7 +94,6 @@ public class TestDevice {
         GenDriverAPI4ModbusFactory factory = DriverFactoryLoader.getModbusDriver();
         GenDriverAPI4Modbus driver = factory.createTcpTransport(testsystemIp, Integer.parseInt(testsystemPort));
         driver.connect();
-        driver.setUnitIdentifier((short) 1);
 
         testSystem = new SGrModbusDevice(deviceDescriptor, driver);
     }
@@ -120,7 +119,6 @@ public class TestDevice {
             GenDriverAPI4ModbusFactory factory = DriverFactoryLoader.getModbusDriver();
             GenDriverAPI4Modbus driver = factory.createRtuTransport(connParams._1, connParams._2);
             driver.connect();
-            driver.setUnitIdentifier(connParams._3.shortValue());
             testSystem = new SGrModbusDevice(deviceDescriptor, driver);
         }
 

--- a/CommHandler/src/test/resources/SGr_04_0014_0000_WAGO_SmartMeterV0.2.1-Arrays.xml
+++ b/CommHandler/src/test/resources/SGr_04_0014_0000_WAGO_SmartMeterV0.2.1-Arrays.xml
@@ -65,7 +65,7 @@
     <modbusRtu>
       <slaveAddr>1</slaveAddr>
       <portName>{{portName}}</portName>
-      <baudRateSelected>9600</baudRateSelected>
+      <baudRateSelected>19200</baudRateSelected>
       <byteLenSelected>8</byteLenSelected>
       <paritySelected>EVEN</paritySelected>
       <stopBitLenSelected>1</stopBitLenSelected>

--- a/CommHandler/src/test/resources/SGr_04_0014_0000_WAGO_SmartMeterV0.2.1-Blocktransfer.xml
+++ b/CommHandler/src/test/resources/SGr_04_0014_0000_WAGO_SmartMeterV0.2.1-Blocktransfer.xml
@@ -65,7 +65,7 @@
         <modbusRtu>
           <slaveAddr>1</slaveAddr>
           <portName>{{portName}}</portName>
-          <baudRateSelected>9600</baudRateSelected>
+          <baudRateSelected>19200</baudRateSelected>
           <byteLenSelected>8</byteLenSelected>
           <paritySelected>EVEN</paritySelected>
           <stopBitLenSelected>1</stopBitLenSelected>

--- a/GenDriverAPI/gradle.properties
+++ b/GenDriverAPI/gradle.properties
@@ -9,4 +9,4 @@
 # 7. regular checkout of release branch to continue development. increment version as soon as required.
 
 # package version to publish
-version=2.1.0-SNAPSHOT
+version=2.2.0-SNAPSHOT

--- a/GenDriverAPI/src/main/java/com/smartgridready/driver/api/modbus/GenDriverAPI4Modbus.java
+++ b/GenDriverAPI/src/main/java/com/smartgridready/driver/api/modbus/GenDriverAPI4Modbus.java
@@ -10,21 +10,70 @@ public interface GenDriverAPI4Modbus {
 
     boolean isConnected();
 	
-	default void setUnitIdentifier( short ident ) {};
+    @Deprecated
+	void setUnitIdentifier(short unitId);
 	
+    @Deprecated
     int[] ReadInputRegisters(int startingAddress, int quantity) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
     
+    @Deprecated
     int[] ReadHoldingRegisters(int startingAddress, int quantity) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
-        
+    
+    @Deprecated
     boolean[] ReadDiscreteInputs(int startingAddress, int quantity) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
 
+    @Deprecated
     boolean[] ReadCoils(int startingAddress, int quantity) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
-       
-    void  WriteMultipleCoils(int startingAdress, boolean[] values) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
     
-    void  WriteSingleCoil(int startingAdress, boolean value) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+    @Deprecated
+    void WriteMultipleCoils(int startingAdress, boolean[] values) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+    
+    @Deprecated
+    void WriteSingleCoil(int startingAdress, boolean value) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
      
-    void  WriteMultipleRegisters(int startingAdress, int[] values) throws GenDriverException, GenDriverSocketException, GenDriverModbusException; 
-     
+    @Deprecated
+    void WriteMultipleRegisters(int startingAdress, int[] values) throws GenDriverException, GenDriverSocketException, GenDriverModbusException; 
+    
+    @Deprecated
     void WriteSingleRegister(int startingAdress, int value) throws GenDriverException, GenDriverSocketException, GenDriverModbusException;
+
+    default int[] readInputRegisters(short unitId, int startingAddress, int quantity) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
+        setUnitIdentifier(unitId);
+        return ReadInputRegisters(startingAddress, quantity);
+    }
+
+    default int[] readHoldingRegisters(short unitId, int startingAddress, int quantity) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
+        setUnitIdentifier(unitId);
+        return ReadHoldingRegisters(startingAddress, quantity);
+    }
+
+    default boolean[] readDiscreteInputs(short unitId, int startingAddress, int quantity) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
+        setUnitIdentifier(unitId);
+        return ReadDiscreteInputs(startingAddress, quantity);
+    }
+
+    default boolean[] readCoils(short unitId, int startingAddress, int quantity) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
+        setUnitIdentifier(unitId);
+        return ReadCoils(startingAddress, quantity);
+    }
+
+    default void writeMultipleRegisters(short unitId, int startingAddress, int[] values) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
+        setUnitIdentifier(unitId);
+        WriteMultipleRegisters(startingAddress, values);
+    }
+
+    default void writeSingleRegister(short unitId, int startingAddress, int value) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
+        setUnitIdentifier(unitId);
+        WriteSingleRegister(startingAddress, value);
+    }
+
+    default void writeMultipleCoils(short unitId, int startingAddress, boolean[] values) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
+        setUnitIdentifier(unitId);
+        WriteMultipleCoils(startingAddress, values);
+    }
+
+    default void writeSingleCoil(short unitId, int startingAddress, boolean value) throws GenDriverException, GenDriverSocketException, GenDriverModbusException {
+        setUnitIdentifier(unitId);
+        WriteSingleCoil(startingAddress, value);
+    }
 }

--- a/GenDriverAPI/src/main/java/com/smartgridready/driver/api/modbus/GenDriverAPI4ModbusFactory.java
+++ b/GenDriverAPI/src/main/java/com/smartgridready/driver/api/modbus/GenDriverAPI4ModbusFactory.java
@@ -12,6 +12,10 @@ public interface GenDriverAPI4ModbusFactory {
 
     public GenDriverAPI4Modbus createRtuTransport(String comPort, int baudRate, Parity parity, DataBits dataBits, StopBits stopBits);
 
+    default GenDriverAPI4Modbus createRtuTransport(String comPort, int baudRate, Parity parity, DataBits dataBits, StopBits stopBits, boolean asciiEncoding) {
+        return createRtuTransport(comPort, baudRate, parity, dataBits, stopBits);
+    }
+
     public GenDriverAPI4Modbus createTcpTransport(String ipAddress);
 
     public GenDriverAPI4Modbus createTcpTransport(String ipAddress, int port);


### PR DESCRIPTION
Improved Modbus driver API and CommHandler:
- unit ID is now part of read/write methods --> 
- support RTU with ASCII encoding
- prepared integration of j2mod as default Modbus driver

first, driver API needs release.
then the j2mod driver must be released.
then the commhandler release can be updated.