### PR TITLE
continue development after releases

### DIFF
--- a/CommHandler/CHANGELOG.md
+++ b/CommHandler/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2025-02-10
+
+### Changed
+
+- uses updated Modbus driver API
+- adapted Modbus implementation to new API
+- changed 'easymodbus' snapshot parameter to 'sgr-driver-modbus'
+- j2mod is new default Modbus driver
+
+
 ## [2.1.2] - 2025-01-06
 
 ### Changed

--- a/CommHandler/build.gradle
+++ b/CommHandler/build.gradle
@@ -60,7 +60,7 @@ test {
 // use release versions by default (no suffix)
 // spec. release date
 def sgr_spec_suffix = '_2024-12-19'
-def sgr_driver_suffix = '-SNAPSHOT'
+def sgr_driver_suffix = ''
 def modbus_suffix = ''
 def apachehttp_suffix = ''
 def hivemq_suffix = ''

--- a/GenDriverAPI/CHANGELOG.md
+++ b/GenDriverAPI/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2025-02-10
+
+### Added
+
+- improved Modbus interface methods
+- support Modbus RTU with ASCII encoding
+
+### Changed
+
+- deprecated 'old' Modbus interface methods
+
+
 ## [2.1.0] - 2024-11-28
 
 ### Added


### PR DESCRIPTION
continue development after driver-api release 2.2.0 and commhandler release 2.2.0.