### PR TITLE
Fix EID property replacement

### DIFF
--- a/CommHandler/CHANGELOG.md
+++ b/CommHandler/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+
+- fixed configuration parameter replacement in EID content when certain characters are used
+
+
 ## [2.3.0] - 2025-03-13
 
 ### Fixed

--- a/CommHandler/src/main/java/com/smartgridready/communicator/common/helper/DeviceDescriptionLoader.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/common/helper/DeviceDescriptionLoader.java
@@ -195,9 +195,10 @@ public class DeviceDescriptionLoader {
 	
 	private static String replacePropertyPlaceholders(String deviceDescriptionXml, Properties properties) {
 		String convertedXml = deviceDescriptionXml;
-		if (properties != null) {
+		if (deviceDescriptionXml != null && properties != null) {
 			for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-				convertedXml = convertedXml.replaceAll("\\{\\{" + entry.getKey() + "\\}\\}", (String)entry.getValue());
+				// no regex here, string literal replacement is sufficient
+				convertedXml = convertedXml.replace("{{" + (String)entry.getKey() + "}}", (String)entry.getValue());
 				LOG.debug("replaced property '{}':'{}'", entry.getKey(), entry.getValue());
 			}
 		}

--- a/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/RestServiceClient.java
+++ b/CommHandler/src/main/java/com/smartgridready/communicator/rest/http/client/RestServiceClient.java
@@ -181,12 +181,11 @@ public class RestServiceClient {
 	}
 
 	private static String replacePropertyPlaceholders(String template, Properties properties) {
-
 		String convertedTemplate = template;
 		if (template != null && properties != null) {
 			for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-				// noinspection RegExpRedundantEscape
-				convertedTemplate = convertedTemplate.replaceAll("\\{\\{" + entry.getKey() + "\\}\\}", (String)entry.getValue());
+				// no regex here, string literal replacement is sufficient
+				convertedTemplate = convertedTemplate.replace("{{" + (String)entry.getKey() + "}}", (String)entry.getValue());
 			}
 		}
 		return convertedTemplate;

--- a/CommHandler/src/test/resources/devicedescriptions.yaml
+++ b/CommHandler/src/test/resources/devicedescriptions.yaml
@@ -57,6 +57,13 @@ descriptions:
       - name: tcp_address
         value: '0.0.0.0'
   - file: SGr_04_mmmm_dddd_CLEMAPEnergyMonitorEIV0.2.1.xml
+    parameters:
+      - name: sensor_id
+        value: '123456'
+      - name: username
+        value: 'test@clemap.local'
+      - name: password
+        value: 'CLEMAP$783#'
   - file: SGr_04_mmmm_dddd_WallboxAsymV0.2.1.xml
     parameters:
       - name: tcp_address


### PR DESCRIPTION
EID properties are replaced without regex, because that caused problems with certain text characters.