### PR TITLE
disable SSL certificate validation in REST

### DIFF
--- a/GenDriverAPI/CHANGELOG.md
+++ b/GenDriverAPI/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2025-04-14
+
+### Added
+
+- added option to disable SSL certificate validation to REST interface
+
+
 ## [2.2.0] - 2025-02-10
 
 ### Added

--- a/GenDriverAPI/gradle.properties
+++ b/GenDriverAPI/gradle.properties
@@ -9,4 +9,4 @@
 # 7. regular checkout of release branch to continue development. increment version as soon as required.
 
 # package version to publish
-version=2.2.0-SNAPSHOT
+version=2.3.0-SNAPSHOT

--- a/GenDriverAPI/src/main/java/com/smartgridready/driver/api/http/GenHttpClientFactory.java
+++ b/GenDriverAPI/src/main/java/com/smartgridready/driver/api/http/GenHttpClientFactory.java
@@ -25,5 +25,7 @@ public interface GenHttpClientFactory {
 
 	GenHttpRequest createHttpRequest();
 
+	GenHttpRequest createHttpRequest(boolean verifyCertificate);
+
 	GenUriBuilder createUriBuilder(String baseUri) throws URISyntaxException;
 }


### PR DESCRIPTION
added option to disable SSL certificate validation to REST client factory.

please merge this with high priority, as it will be required by upcoming java release 2.4 (dynamic parameters etc.)