### PR TITLE
prepared bugfix releases

### DIFF
--- a/CommHandler/CHANGELOG.md
+++ b/CommHandler/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.4.2] - 2025-09-09
 
 ### Fixed
 
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated specification to `2.1_2025-09-02`, adds W/m2
+- updated Gradle build file
 
 ## [2.4.1] - 2025-05-20
 

--- a/CommHandler/build.gradle
+++ b/CommHandler/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     api group: 'com.smartgridready', name: 'sgr-specification', version: "2.1${sgr_spec_suffix}"
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
 
-    api group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.3.1${sgr_driver_suffix}"
+    api group: 'com.smartgridready', name: 'sgr-driver-api', version: "2.3.2${sgr_driver_suffix}"
     testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-j2mod', version: "1.0.0${modbus_suffix}"
     testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-apachehttp', version: "2.1.1${apachehttp_suffix}"
     testRuntimeOnly group: 'com.smartgridready', name: 'sgr-driver-hivemq', version: "2.0.1${hivemq_suffix}"

--- a/CommHandler/gradle.properties
+++ b/CommHandler/gradle.properties
@@ -9,7 +9,7 @@
 # 7. regular checkout of release branch to continue development. increment version as soon as required.
 
 # package version to publish
-version=2.4.1-SNAPSHOT
+version=2.4.2-SNAPSHOT
 
 # snapshots to use
 snapshots=

--- a/GenDriverAPI/CHANGELOG.md
+++ b/GenDriverAPI/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2025-09-09
+
+### Changed
+
+- cleaned up documentation and javadoc
+- updated Gradle build file
+
+
 ## [2.3.1] - 2025-05-13
 
 ### Added

--- a/GenDriverAPI/gradle.properties
+++ b/GenDriverAPI/gradle.properties
@@ -9,4 +9,4 @@
 # 7. regular checkout of release branch to continue development. increment version as soon as required.
 
 # package version to publish
-version=2.3.1-SNAPSHOT
+version=2.3.2-SNAPSHOT


### PR DESCRIPTION
check may fail until driver API package has been updated.

but this PR is only for creating the releases, so it should not matter.